### PR TITLE
keyPressNative, keyDownNative, keyUpNative fixed to take int parameter

### DIFF
--- a/api/src/main/java/org/jboss/arquillian/ajocado/framework/TypedSelenium.java
+++ b/api/src/main/java/org/jboss/arquillian/ajocado/framework/TypedSelenium.java
@@ -21,7 +21,6 @@
  */
 package org.jboss.arquillian.ajocado.framework;
 
-import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
 import java.net.URL;
 import java.util.List;
@@ -1597,7 +1596,7 @@ public interface TypedSelenium {
      * @param keycode
      *            java.awt.event.KeyEvent
      */
-    void keyDownNative(KeyEvent keycode);
+    void keyDownNative(int keycode);
 
     /**
      * Simulates a user releasing a key by sending a native operating system keystroke. This function uses the
@@ -1609,7 +1608,7 @@ public interface TypedSelenium {
      * @param keycode
      *            java.awt.event.KeyEvent
      */
-    void keyUpNative(KeyEvent keycode);
+    void keyUpNative(int keycode);
 
     /**
      * Simulates a user pressing and releasing a key by sending a native operating system keystroke. This function uses
@@ -1621,7 +1620,7 @@ public interface TypedSelenium {
      * @param keycode
      *            java.awt.event.KeyEvent
      */
-    void keyPressNative(KeyEvent keycode);
+    void keyPressNative(int keycode);
 
     /**
      * Capture a PNG screenshot. It then returns the file as a base 64 encoded string.

--- a/impl/src/main/java/org/jboss/arquillian/ajocado/framework/TypedSeleniumImpl.java
+++ b/impl/src/main/java/org/jboss/arquillian/ajocado/framework/TypedSeleniumImpl.java
@@ -21,7 +21,6 @@
  */
 package org.jboss.arquillian.ajocado.framework;
 
-import java.awt.event.KeyEvent;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -465,7 +464,7 @@ public class TypedSeleniumImpl implements TypedSelenium, UnsupportedTypedSeleniu
         selenium.keyPress(elementLocator.inSeleniumRepresentation(), keyCode.inSeleniumRepresentation());
     }
 
-    public void keyDownNative(KeyEvent keycode) {
+    public void keyDownNative(int keycode) {
         selenium.keyDownNative(keyEventToNativeCode(keycode));
     }
 
@@ -477,7 +476,7 @@ public class TypedSeleniumImpl implements TypedSelenium, UnsupportedTypedSeleniu
         selenium.keyPress(elementLocator.inSeleniumRepresentation(), keyCode.inSeleniumRepresentation());
     }
 
-    public void keyPressNative(KeyEvent keycode) {
+    public void keyPressNative(int keycode) {
         selenium.keyPressNative(keyEventToNativeCode(keycode));
     }
     
@@ -489,7 +488,7 @@ public class TypedSeleniumImpl implements TypedSelenium, UnsupportedTypedSeleniu
         selenium.keyPress(elementLocator.inSeleniumRepresentation(), keyCode.inSeleniumRepresentation());
     }
 
-    public void keyUpNative(KeyEvent keycode) {
+    public void keyUpNative(int keycode) {
         selenium.keyUpNative(keyEventToNativeCode(keycode));
     }
 
@@ -754,7 +753,7 @@ public class TypedSeleniumImpl implements TypedSelenium, UnsupportedTypedSeleniu
         selenium.addCustomRequestHeader(header.getName(), header.getValue());
     }
     
-    private static String keyEventToNativeCode(KeyEvent event) {
-        return Integer.toString(event.getKeyCode());
+    private static String keyEventToNativeCode(int event) {
+        return Integer.toString(event);
     }
 }


### PR DESCRIPTION
methods keyPressNative, keyDownNative, keyUpNative took as parameter KeyEvent instance, since in this class there are keyevents as integers I changed this parameter to int, and now for example it is possible to call selenium.keyPressNative(KeyEvent.VK_CONTROL)
