### PR TITLE
ARQAJO-74 A temporal fix for TestNG pom, updated versions

### DIFF
--- a/ftest-junit/pom.xml
+++ b/ftest-junit/pom.xml
@@ -59,6 +59,29 @@
     <profiles>
         <profile>
             <id>ftest</id>
+
+            <properties>
+                <!-- versioning -->
+                <version.org.jboss.jbossas>6.0.0.Final</version.org.jboss.jbossas>
+                <version.arquillian.container.jboss>1.0.0.CR1</version.arquillian.container.jboss>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-jbossas-managed-6</artifactId>
+                    <scope>test</scope>
+                    <version>${version.arquillian.container.jboss}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.jbossas</groupId>
+                    <artifactId>jboss-as-client</artifactId>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <version>${version.org.jboss.jbossas}</version>
+                </dependency>
+            </dependencies>
+
             <build>
                 <plugins>
                     <plugin>
@@ -73,24 +96,33 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.jboss.jbossas</groupId>
+                                            <artifactId>jboss-as-distribution</artifactId>
+                                            <version>${version.org.jboss.jbossas}</version>
+                                            <type>zip</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
-
-            <dependencies>
-                <dependency>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                    <artifactId>arquillian-jbossas-remote-6</artifactId>
-                    <version>1.0.0-SNAPSHOT</version>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.jboss.jbossas</groupId>
-                    <artifactId>jboss-as-client</artifactId>
-                    <version>6.0.0.Final</version>
-                    <type>pom</type>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
 
         </profile>
 

--- a/ftest-junit/src/test/java/org/jboss/arquillian/ajocado/junit/ftest/AttributePresentTestCase.java
+++ b/ftest-junit/src/test/java/org/jboss/arquillian/ajocado/junit/ftest/AttributePresentTestCase.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.ajocado.testng.ftest;
+package org.jboss.arquillian.ajocado.junit.ftest;
 
 import static org.jboss.arquillian.ajocado.Ajocado.attributePresent;
 import static org.jboss.arquillian.ajocado.locator.LocatorFactory.id;

--- a/ftest-junit/src/test/java/org/jboss/arquillian/ajocado/junit/ftest/EscapingTestCase.java
+++ b/ftest-junit/src/test/java/org/jboss/arquillian/ajocado/junit/ftest/EscapingTestCase.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.ajocado.testng.ftest;
+package org.jboss.arquillian.ajocado.junit.ftest;
 
 import static org.jboss.arquillian.ajocado.Ajocado.jq;
 import static org.jboss.arquillian.ajocado.Ajocado.retrieveAttribute;

--- a/ftest-junit/src/test/java/org/jboss/arquillian/ajocado/junit/ftest/RequestGuardTestCase.java
+++ b/ftest-junit/src/test/java/org/jboss/arquillian/ajocado/junit/ftest/RequestGuardTestCase.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.ajocado.testng.ftest;
+package org.jboss.arquillian.ajocado.junit.ftest;
 
 import static org.jboss.arquillian.ajocado.Ajocado.guardHttp;
 import static org.jboss.arquillian.ajocado.Ajocado.guardNoRequest;

--- a/ftest-junit/src/test/java/org/jboss/arquillian/ajocado/junit/ftest/RequestGuardTimingTestCase.java
+++ b/ftest-junit/src/test/java/org/jboss/arquillian/ajocado/junit/ftest/RequestGuardTimingTestCase.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.ajocado.testng.ftest;
+package org.jboss.arquillian.ajocado.junit.ftest;
 
 import static org.jboss.arquillian.ajocado.Ajocado.guardHttp;
 import static org.jboss.arquillian.ajocado.Ajocado.guardNoRequest;

--- a/ftest-junit/src/test/java/org/jboss/arquillian/ajocado/junit/ftest/RestartBrowserTestCase.java
+++ b/ftest-junit/src/test/java/org/jboss/arquillian/ajocado/junit/ftest/RestartBrowserTestCase.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.ajocado.testng.ftest;
+package org.jboss.arquillian.ajocado.junit.ftest;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;

--- a/ftest-junit/src/test/java/org/jboss/arquillian/ajocado/junit/ftest/SampleApplication.java
+++ b/ftest-junit/src/test/java/org/jboss/arquillian/ajocado/junit/ftest/SampleApplication.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.ajocado.testng.ftest;
+package org.jboss.arquillian.ajocado.junit.ftest;
 
 import java.io.File;
 import java.net.URL;

--- a/ftest-junit/src/test/resources/arquillian.xml
+++ b/ftest-junit/src/test/resources/arquillian.xml
@@ -23,19 +23,32 @@
 
 -->
 <arquillian xmlns="http://jboss.com/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-	<extension qualifier="selenium-server">
-		<configuration>
-			<property name="enable">true</property>
-		</configuration>
-	</extension>
+    <engine>
+        <property name="deploymentExportPath">target/</property>
+    </engine>
 
-	<extension qualifier="ajocado">
-		<configuration>
-			<property name="browser">*firefox</property>
-			<property name="contextRoot">http://localhost:9090/</property>
-			<property name="seleniumTimeoutAjax">5000</property>
-		</configuration>
-	</extension>
+    <container qualifier="jboss" default="true">
+        <configuration>
+            <property name="jbossHome">target/jboss-6.0.0.Final</property>
+            <!-- <property name="javaHome">/usr/lib/jvm/java-6-openjdk/</property> -->
+            <property name="bindAddress">127.0.0.1</property>
+            <property name="httpPort">8080</property>
+        </configuration>
+    </container>
+
+    <extension qualifier="selenium-server">
+        <configuration>
+            <property name="enable">true</property>
+        </configuration>
+    </extension>
+
+    <extension qualifier="ajocado">
+        <configuration>
+            <property name="browser">*firefox</property>
+            <property name="contextRoot">http://localhost:9090/</property>
+            <property name="seleniumTimeoutAjax">5000</property>
+        </configuration>
+    </extension>
 </arquillian>

--- a/ftest-testng/pom.xml
+++ b/ftest-testng/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>org.jboss.arquillian.ajocado</groupId>
             <artifactId>arquillian-ajocado-testng</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>${project.version}</version>
             <type>pom</type>
             <scope>test</scope>
         </dependency>
@@ -58,6 +58,29 @@
     <profiles>
         <profile>
             <id>ftest</id>
+
+            <properties>
+                <!-- versioning -->
+                <version.org.jboss.jbossas>6.0.0.Final</version.org.jboss.jbossas>
+                <version.arquillian.container.jboss>1.0.0.CR1</version.arquillian.container.jboss>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-jbossas-managed-6</artifactId>
+                    <scope>test</scope>
+                    <version>${version.arquillian.container.jboss}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.jbossas</groupId>
+                    <artifactId>jboss-as-client</artifactId>
+                    <type>pom</type>
+                    <scope>test</scope>
+                    <version>${version.org.jboss.jbossas}</version>
+                </dependency>
+            </dependencies>
+
             <build>
                 <plugins>
                     <plugin>
@@ -72,22 +95,34 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>process-test-classes</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.jboss.jbossas</groupId>
+                                            <artifactId>jboss-as-distribution</artifactId>
+                                            <version>${version.org.jboss.jbossas}</version>
+                                            <type>zip</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
 
-            <dependencies>
-                <dependency>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                    <artifactId>arquillian-jbossas-remote-6</artifactId>
-                    <version>1.0.0-SNAPSHOT</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.jboss.jbossas</groupId>
-                    <artifactId>jboss-as-client</artifactId>
-                    <version>6.0.0.Final</version>
-                    <type>pom</type>
-                </dependency>
-            </dependencies>
 
         </profile>
     </profiles>

--- a/ftest-testng/src/test/resources/arquillian.xml
+++ b/ftest-testng/src/test/resources/arquillian.xml
@@ -25,6 +25,19 @@
 <arquillian xmlns="http://jboss.com/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <engine>
+        <property name="deploymentExportPath">target/</property>
+    </engine>
+
+    <container qualifier="jboss" default="true">
+        <configuration>
+            <property name="jbossHome">target/jboss-6.0.0.Final</property>
+            <!-- <property name="javaHome">/usr/lib/jvm/java-6-openjdk/</property> -->
+            <property name="bindAddress">127.0.0.1</property>
+            <property name="httpPort">8080</property>
+        </configuration>
+    </container>
+
 	<extension qualifier="selenium-server">
 		<configuration>
 			<property name="enable">true</property>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <module>drone</module>
         <module>testng</module>
         <module>junit</module>
-     <!--    <module>ftest-testng</module> -->
+        <module>ftest-testng</module>
         <module>ftest-junit</module> 
     </modules>
 
@@ -81,8 +81,9 @@
         <useReleaseProfile>true</useReleaseProfile>
         
         <!-- Versioning -->
-        <version.arquillian.core>1.0.0.CR1-SNAPSHOT</version.arquillian.core>
+        <version.arquillian.core>1.0.0.CR1</version.arquillian.core>
         <version.arquillian.drone>1.0.0.CR1-SNAPSHOT</version.arquillian.drone>
+        <version.shrinkwrap>1.0.0-beta-3</version.shrinkwrap>
     </properties>
 
     <build>
@@ -234,6 +235,13 @@
             </dependency>
 
             <!-- External dependencies -->
+            <!-- required until ARQ-488 is fixed -->
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-impl-base</artifactId>
+                <version>${version.shrinkwrap}</version>
+            </dependency>
+
             <dependency>
                 <groupId>commons-lang</groupId>
                 <artifactId>commons-lang</artifactId>

--- a/testng/pom.xml
+++ b/testng/pom.xml
@@ -53,6 +53,11 @@
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
         </dependency>
+        <!-- required until ARQ-488 is fixed -->
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>


### PR DESCRIPTION
Hi Lukas,

can you incorporate following fix so we can prepare the CR1 release?
- Changed containers back to managed version
- Updated Arquillian versions to CR1

Thanks,

Karel
