### PR TITLE
ARQGRA-241: Double quotes in jquery locators fixed

### DIFF
--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/page/extension/JQuerySelectorsPageExtensionTestCase.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/page/extension/JQuerySelectorsPageExtensionTestCase.java
@@ -64,13 +64,20 @@ public class JQuerySelectorsPageExtensionTestCase {
     @FindBy(jquery = "#nonExistingId")
     private List<WebElement> notExistingElements;
 
+    private static final String contentOfSpecialCharacters = "special chars '\"$";
+    @FindBy(jquery = "p:contains(\"" + contentOfSpecialCharacters + "\")")
+    private WebElement escapedDoubleQuotes;
+
+    @FindBy(jquery = "div[id=\"foo:bar\"]")
+    private WebElement escapedDoubleQuotes2;
+
     @Drone
     private WebDriver browser;
 
-    private static String EXPECTED_JQUERY_TEXT_1 = "Hello jquery selectors!";
-    private static String EXPECTED_JQUERY_TEXT_2 = "Nested div with foo class.";
-    private static String EXPECTED_NO_SUCH_EL_EX_MSG = "Cannot locate element using";
-    private static String EXPECTED_WRONG_SELECTOR_MSG = "Check out whether it is correct!";
+    private static final String EXPECTED_JQUERY_TEXT_1 = "Hello jquery selectors!";
+    private static final String EXPECTED_JQUERY_TEXT_2 = "Nested div with foo class.";
+    private static final String EXPECTED_NO_SUCH_EL_EX_MSG = "Cannot locate element using";
+    private static final String EXPECTED_WRONG_SELECTOR_MSG = "Check out whether it is correct!";
 
     public void loadPage() {
         URL page = this.getClass().getClassLoader()
@@ -182,6 +189,22 @@ public class JQuerySelectorsPageExtensionTestCase {
         loadPage();
 
         assertEquals("When locating not existing elements an empty list should be returned!", 0, notExistingElements.size());
+    }
+
+    @Test
+    public void testEscapedDoubleQuotesSelector() {
+        loadPage();
+
+        String actual = escapedDoubleQuotes.getText().trim();
+        assertEquals("WebElement referenced by ecaped locator was not found correctly!", contentOfSpecialCharacters, actual);
+    }
+
+    @Test
+    public void testEscapedColonSelector() {
+        loadPage();
+
+        String actual = escapedDoubleQuotes2.getText().trim();
+        assertEquals("WebElement with locator containing escaped colon not located correctly!", "Some content", actual);
     }
 
     /* *************

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/resources/org/jboss/arquillian/graphene/ftest/page/extension/sampleJQueryLocator.html
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/resources/org/jboss/arquillian/graphene/ftest/page/extension/sampleJQueryLocator.html
@@ -8,6 +8,8 @@
 	<div id="root">
 		<div>Hello jquery selectors!</div>
 		<div class="foo">Nested div with foo class.</div>
+		<p>special chars '"$</p>
+		<div id="foo:bar">Some content</div>
 	</div>
 </body>
 </html>

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/findby/ByJQuery.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/findby/ByJQuery.java
@@ -47,7 +47,7 @@ public class ByJQuery extends By {
     private JavascriptExecutor executor = GrapheneContext.getProxyForInterfaces(JavascriptExecutor.class);
 
     public ByJQuery(String jquerySelector) {
-        this.jquerySelector = jquerySelector;
+        this.jquerySelector = jquerySelector.replaceAll("\\\"", "\\\\\"");
     }
 
     public static ByJQuery jquerySelector(String selector) {
@@ -71,10 +71,11 @@ public class ByJQuery extends By {
         try {
             // the element is referenced from parent web element
             if (context instanceof WebElement) {
-                elements = (List<WebElement>) executor.executeScript(
-                    "return Graphene.jQuery(\"" + jquerySelector + "\", arguments[0]).get()", (WebElement) context);
+                elements = (List<WebElement>) executor.executeScript("return Graphene.jQuery(\"" + jquerySelector
+                    + "\", arguments[0]).get()", (WebElement) context);
             } else if (context instanceof WebDriver) { // element is not referenced from parent
-                elements = (List<WebElement>) executor.executeScript("return Graphene.jQuery(\"" + jquerySelector + "\").get()");
+                elements = (List<WebElement>) executor
+                    .executeScript("return Graphene.jQuery(\"" + jquerySelector + "\").get()");
             } else { // other unknown case
                 Logger
                     .getLogger(this.getClass().getName())


### PR DESCRIPTION
Double quotes in JQuery locators need to be escaped properly. To be
consitent with WebDriver `@FindBy` one needs to escape double quotes like:
`":contains(\"foo\")".`
