### PR TITLE
Fix for more helpful graphene exception message

### DIFF
--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/WebElementEnricher.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/WebElementEnricher.java
@@ -42,7 +42,7 @@ public class WebElementEnricher extends AbstractSearchContextEnricher {
             List<Field> fields = FindByUtilities.getListOfFieldsAnnotatedWithFindBys(target);
             for (Field field : fields) {
                 By by = FindByUtilities.getCorrectBy(field);
-                String message = "Your @FindBy annotation over field " + NEW_LINE + field.getClass() + NEW_LINE
+                String message = "Your @FindBy annotation over field " + NEW_LINE + field.getName() + NEW_LINE
                     + " declared in: " + NEW_LINE + field.getDeclaringClass().getName() + NEW_LINE
                     + " is annotated with empty @FindBy annotation, in other words it "
                     + "should contain parameter which will define the strategy for referencing that element.";


### PR DESCRIPTION
have the exception message that complains about empty FindBy annotations refer to the field name instead of its class.
