### PR TITLE
ARQGRA-197: page objects location encapsulation - first try - not stable

### DIFF
--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/findby/TestFindByLongLocatingMethod.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/findby/TestFindByLongLocatingMethod.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.findby;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/findby/TestHandlingOfStaleElements.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/findby/TestHandlingOfStaleElements.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.findby;
 
 import static org.junit.Assert.fail;
 

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/findby/TestInitializeEmptyFindBy.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/findby/TestInitializeEmptyFindBy.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.findby;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/findby/TestInitializeFindBys.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/findby/TestInitializeFindBys.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.findby;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/findby/TestWebElementWrapper.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/findby/TestWebElementWrapper.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.findby;
 
 import java.net.URL;
 import junit.framework.Assert;

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/TestEnrichingContainerElement.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/TestEnrichingContainerElement.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.pageFragments;
 
 import static org.junit.Assert.assertEquals;
 
@@ -27,8 +27,8 @@ import java.net.URL;
 
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.enricher.findby.FindBy;
-import org.jboss.arquillian.graphene.enricher.page.fragment.Panel;
-import org.jboss.arquillian.graphene.enricher.page.fragment.TabPanel;
+import org.jboss.arquillian.graphene.enricher.pageFragments.fragments.Panel;
+import org.jboss.arquillian.graphene.enricher.pageFragments.fragments.TabPanel;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Before;
 import org.junit.Test;

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/TestInitializeNestedPageFragments.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/TestInitializeNestedPageFragments.java
@@ -19,42 +19,42 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.pageFragments;
 
 import static org.junit.Assert.assertNotNull;
 
-import org.jboss.arquillian.graphene.spi.annotations.Page;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.support.FindBy;
 
 /**
- * @author <a href="mailto:jhuska@redhat.com">Juraj Huska</a>
+ * @author Juraj Huska
  */
 @RunWith(Arquillian.class)
-public class TestInitializingNestedPageObjects {
+public class TestInitializeNestedPageFragments {
 
-    @Page
-    private InnerPageObject innerPageObject;
+    @FindBy(id = "foo")
+    private InnerPageFragment innerPageFragment;
 
-    @Page
-    private NestedStaticPageObject nestedStaticPageObject;
-
-    @Test
-    public void testInitializingInnerPageObjects() {
-        assertNotNull("The inner page object should be already initialized!", innerPageObject);
-    }
+    @FindBy(id = "foo")
+    private NestedStaticPageFragment nestedStaticPageFragment;
 
     @Test
-    public void testInitializingNesteStaticClasses() {
-        assertNotNull("The nested static page object should be already initialized!", nestedStaticPageObject);
+    public void testInnerPageFragmentInitialized() {
+        assertNotNull("The inner page fragment should be already initialized!", innerPageFragment);
     }
 
-    public class InnerPageObject {
+    @Test
+    public void testNestedStaticPageFragmentInitialized() {
+        assertNotNull("The nested static page fragment should be already initialized!", nestedStaticPageFragment);
+    }
+
+    public class InnerPageFragment {
 
     }
 
-    public static class NestedStaticPageObject {
+    public static class NestedStaticPageFragment {
 
     }
 }

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/TestInitializingPageFragments.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/TestInitializingPageFragments.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.pageFragments;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -31,9 +31,9 @@ import java.util.List;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.context.GrapheneContext;
 import org.jboss.arquillian.graphene.enricher.fragment.AbstractPageFragmentStub;
-import org.jboss.arquillian.graphene.enricher.page.EmbeddedPage;
-import org.jboss.arquillian.graphene.enricher.page.TestPage;
-import org.jboss.arquillian.graphene.enricher.page.fragment.PageFragmentWithEmbeddedAnotherPageFragmentStub;
+import org.jboss.arquillian.graphene.enricher.pageFragments.fragments.PageFragmentWithEmbeddedAnotherPageFragmentStub;
+import org.jboss.arquillian.graphene.enricher.pageObjects.pages.EmbeddedPage;
+import org.jboss.arquillian.graphene.enricher.pageObjects.pages.TestPage;
 import org.jboss.arquillian.graphene.spi.annotations.Page;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/TestPageFragmentList.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/TestPageFragmentList.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.pageFragments;
 
 import java.net.URL;
 import java.util.List;

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/TestSamplePageFragment.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/TestSamplePageFragment.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.pageFragments;
 
 import java.net.URL;
 import junit.framework.Assert;

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/fragments/PageFragmentWithEmbeddedAnotherPageFragmentStub.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/fragments/PageFragmentWithEmbeddedAnotherPageFragmentStub.java
@@ -19,42 +19,32 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.pageFragments.fragments;
 
-import static org.junit.Assert.assertNotNull;
-
-import org.jboss.arquillian.junit.Arquillian;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.jboss.arquillian.graphene.enricher.fragment.AbstractPageFragmentStub;
+import org.jboss.arquillian.graphene.spi.annotations.Root;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
 /**
  * @author Juraj Huska
  */
-@RunWith(Arquillian.class)
-public class TestInitializeNestedPageFragments {
+public class PageFragmentWithEmbeddedAnotherPageFragmentStub {
 
-    @FindBy(id = "foo")
-    private InnerPageFragment innerPageFragment;
+    @SuppressWarnings("unused")
+    @Root
+    private WebElement root;
 
-    @FindBy(id = "foo")
-    private NestedStaticPageFragment nestedStaticPageFragment;
+    @FindBy(className="rootOfEmbeddedPageFragment")
+    private AbstractPageFragmentStub embeddedPageFragment;
 
-    @Test
-    public void testInnerPageFragmentInitialized() {
-        assertNotNull("The inner page fragment should be already initialized!", innerPageFragment);
+    public AbstractPageFragmentStub getEmbeddedPageFragment() {
+        return embeddedPageFragment;
     }
 
-    @Test
-    public void testNestedStaticPageFragmentInitialized() {
-        assertNotNull("The nested static page fragment should be already initialized!", nestedStaticPageFragment);
+    public void setEmbeddedPageFragment(AbstractPageFragmentStub embeddedPageFragment) {
+        this.embeddedPageFragment = embeddedPageFragment;
     }
 
-    public class InnerPageFragment {
 
-    }
-
-    public static class NestedStaticPageFragment {
-
-    }
 }

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/fragments/Panel.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/fragments/Panel.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher.page.fragment;
+package org.jboss.arquillian.graphene.enricher.pageFragments.fragments;
 
 import org.jboss.arquillian.graphene.component.object.api.switchable.ComponentContainer;
 import org.jboss.arquillian.graphene.enricher.PageFragmentEnricher;

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/fragments/TabPanel.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageFragments/fragments/TabPanel.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher.page.fragment;
+package org.jboss.arquillian.graphene.enricher.pageFragments.fragments;
 
 import static org.jboss.arquillian.graphene.Graphene.guardHttp;
 import static org.jboss.arquillian.graphene.Graphene.guardXhr;

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/AbstractTest.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/AbstractTest.java
@@ -1,9 +1,9 @@
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.pageObjects;
 
 import java.net.URL;
 
 import org.jboss.arquillian.drone.api.annotation.Drone;
-import org.jboss.arquillian.graphene.enricher.page.AbstractPage;
+import org.jboss.arquillian.graphene.enricher.pageObjects.pages.AbstractPage;
 import org.jboss.arquillian.graphene.spi.annotations.Page;
 import org.openqa.selenium.WebDriver;
 

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/MoreSpecificAbstractTest.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/MoreSpecificAbstractTest.java
@@ -1,6 +1,6 @@
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.pageObjects;
 
-import org.jboss.arquillian.graphene.enricher.page.AbstractPage;
+import org.jboss.arquillian.graphene.enricher.pageObjects.pages.AbstractPage;
 
 /**
  * @author <a href="mailto:jhuska@redhat.com">Juraj Huska</a>

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/TestDroneIntegrationWhenDroneIsUsedInTest.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/TestDroneIntegrationWhenDroneIsUsedInTest.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.pageObjects;
 
 import java.net.URL;
 import junit.framework.Assert;

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/TestInitializingGenericPageObjects1.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/TestInitializingGenericPageObjects1.java
@@ -1,9 +1,9 @@
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.pageObjects;
 
 import static org.junit.Assert.assertEquals;
 
-import org.jboss.arquillian.graphene.enricher.page.TestPage;
-import org.jboss.arquillian.graphene.enricher.page.TestPage2;
+import org.jboss.arquillian.graphene.enricher.pageObjects.pages.TestPage;
+import org.jboss.arquillian.graphene.enricher.pageObjects.pages.TestPage2;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
  * @author <a href="mailto:jhuska@redhat.com">Juraj Huska</a>
  */
 @RunWith(Arquillian.class)
-public class TestInitializingGenericPageObjects2 extends AbstractTest<TestPage, TestPage2> {
+public class TestInitializingGenericPageObjects1 extends MoreSpecificAbstractTest<TestPage, TestPage2> {
 
     private final String EXPECTED_NESTED_ELEMENT_TEXT = "Some Value";
 

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/TestInitializingGenericPageObjects2.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/TestInitializingGenericPageObjects2.java
@@ -1,9 +1,9 @@
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.pageObjects;
 
 import static org.junit.Assert.assertEquals;
 
-import org.jboss.arquillian.graphene.enricher.page.TestPage;
-import org.jboss.arquillian.graphene.enricher.page.TestPage2;
+import org.jboss.arquillian.graphene.enricher.pageObjects.pages.TestPage;
+import org.jboss.arquillian.graphene.enricher.pageObjects.pages.TestPage2;
 import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
  * @author <a href="mailto:jhuska@redhat.com">Juraj Huska</a>
  */
 @RunWith(Arquillian.class)
-public class TestInitializingGenericPageObjects1 extends MoreSpecificAbstractTest<TestPage, TestPage2> {
+public class TestInitializingGenericPageObjects2 extends AbstractTest<TestPage, TestPage2> {
 
     private final String EXPECTED_NESTED_ELEMENT_TEXT = "Some Value";
 

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/TestInitializingGenericPageObjects3.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/TestInitializingGenericPageObjects3.java
@@ -19,23 +19,24 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher;
+package org.jboss.arquillian.graphene.enricher.pageObjects;
+
+import static org.junit.Assert.assertEquals;
 
 import org.jboss.arquillian.graphene.enricher.fragment.AbstractPageFragmentStub;
-import org.jboss.arquillian.graphene.enricher.page.TestPage;
+import org.jboss.arquillian.graphene.enricher.pageObjects.pages.TestPage;
 import org.jboss.arquillian.graphene.spi.annotations.Page;
 import org.jboss.arquillian.junit.Arquillian;
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
 /**
- * @author <a href="mailto:jpapouse@redhat.com">Jan Papousek</a>
+ * @author <a href="mailto:jhuska@redhat.com">Juraj Huska</a>
  */
 @RunWith(Arquillian.class)
-public class TestInitializingGenericPageObjects4 extends AbstractTest<TestPage, TestInitializingGenericPageObjects4.InnerTestPage> {
+public class TestInitializingGenericPageObjects3 extends AbstractTest<TestPage, TestInitializingGenericPageObjects3.InnerTestPage> {
 
     @Page
     private InnerTestPage innerTestPageNotGeneric;
@@ -56,7 +57,7 @@ public class TestInitializingGenericPageObjects4 extends AbstractTest<TestPage, 
             actual);
     }
 
-    protected static class InnerTestPage {
+    protected class InnerTestPage {
 
         @FindBy(xpath = "//div[@id='rootElement']")
         private AbstractPageFragmentStub abstractPageFragment;
@@ -92,5 +93,4 @@ public class TestInitializingGenericPageObjects4 extends AbstractTest<TestPage, 
         }
 
     }
-
 }

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/TestInitializingGenericPageObjects4.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/TestInitializingGenericPageObjects4.java
@@ -19,24 +19,23 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher;
-
-import static org.junit.Assert.assertEquals;
+package org.jboss.arquillian.graphene.enricher.pageObjects;
 
 import org.jboss.arquillian.graphene.enricher.fragment.AbstractPageFragmentStub;
-import org.jboss.arquillian.graphene.enricher.page.TestPage;
+import org.jboss.arquillian.graphene.enricher.pageObjects.pages.TestPage;
 import org.jboss.arquillian.graphene.spi.annotations.Page;
 import org.jboss.arquillian.junit.Arquillian;
+import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
 /**
- * @author <a href="mailto:jhuska@redhat.com">Juraj Huska</a>
+ * @author <a href="mailto:jpapouse@redhat.com">Jan Papousek</a>
  */
 @RunWith(Arquillian.class)
-public class TestInitializingGenericPageObjects3 extends AbstractTest<TestPage, TestInitializingGenericPageObjects3.InnerTestPage> {
+public class TestInitializingGenericPageObjects4 extends AbstractTest<TestPage, TestInitializingGenericPageObjects4.InnerTestPage> {
 
     @Page
     private InnerTestPage innerTestPageNotGeneric;
@@ -57,7 +56,7 @@ public class TestInitializingGenericPageObjects3 extends AbstractTest<TestPage, 
             actual);
     }
 
-    protected class InnerTestPage {
+    protected static class InnerTestPage {
 
         @FindBy(xpath = "//div[@id='rootElement']")
         private AbstractPageFragmentStub abstractPageFragment;
@@ -93,4 +92,5 @@ public class TestInitializingGenericPageObjects3 extends AbstractTest<TestPage, 
         }
 
     }
+
 }

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/TestInitializingNestedPageObjects.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/TestInitializingNestedPageObjects.java
@@ -19,32 +19,42 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher.page.fragment;
+package org.jboss.arquillian.graphene.enricher.pageObjects;
 
-import org.jboss.arquillian.graphene.enricher.fragment.AbstractPageFragmentStub;
-import org.jboss.arquillian.graphene.spi.annotations.Root;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
+import static org.junit.Assert.assertNotNull;
+
+import org.jboss.arquillian.graphene.spi.annotations.Page;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
- * @author Juraj Huska
+ * @author <a href="mailto:jhuska@redhat.com">Juraj Huska</a>
  */
-public class PageFragmentWithEmbeddedAnotherPageFragmentStub {
+@RunWith(Arquillian.class)
+public class TestInitializingNestedPageObjects {
 
-    @SuppressWarnings("unused")
-    @Root
-    private WebElement root;
+    @Page
+    private InnerPageObject innerPageObject;
 
-    @FindBy(className="rootOfEmbeddedPageFragment")
-    private AbstractPageFragmentStub embeddedPageFragment;
+    @Page
+    private NestedStaticPageObject nestedStaticPageObject;
 
-    public AbstractPageFragmentStub getEmbeddedPageFragment() {
-        return embeddedPageFragment;
+    @Test
+    public void testInitializingInnerPageObjects() {
+        assertNotNull("The inner page object should be already initialized!", innerPageObject);
     }
 
-    public void setEmbeddedPageFragment(AbstractPageFragmentStub embeddedPageFragment) {
-        this.embeddedPageFragment = embeddedPageFragment;
+    @Test
+    public void testInitializingNesteStaticClasses() {
+        assertNotNull("The nested static page object should be already initialized!", nestedStaticPageObject);
     }
 
+    public class InnerPageObject {
 
+    }
+
+    public static class NestedStaticPageObject {
+
+    }
 }

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/TestPageObjectsLocation.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/TestPageObjectsLocation.java
@@ -1,0 +1,93 @@
+package org.jboss.arquillian.graphene.enricher.pageObjects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.hamcrest.Matcher;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.enricher.findby.FindBy;
+import org.jboss.arquillian.graphene.spi.annotations.Location;
+import org.jboss.arquillian.graphene.spi.annotations.Page;
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.matchers.JUnitMatchers;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+@RunWith(Arquillian.class)
+public class TestPageObjectsLocation {
+
+    @Page
+    private MyPageObject1 pageObject1;
+
+    @Page
+    private MyPageObject2 pageObject2;
+
+    @Page
+    private MyPageObjectEmptyLocationClass pageObjectEmptyLocation;
+
+    @Page
+    private MyPageObjectWrongURL pageObjectWrongURL;
+
+    @Drone
+    @SuppressWarnings("unused")
+    private WebDriver browser;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testPageObjectsAreInitialized() {
+        assertNotNull(pageObject1);
+        assertNotNull(pageObject2);
+    }
+
+    @Test
+    public void testCorrectPageIsOpened1(@Location MyPageObject1 obj) {
+        String actual = pageObject1.element.getText();
+        assertEquals("pseudo root", actual);
+    }
+
+    @Test
+    public void testCorrectPageIsOpened2(@Location MyPageObject2 obj) {
+        String actual = pageObject2.element.getText();
+        assertEquals("WebElement content", actual);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLocationIsEmpty(@Location MyPageObjectEmptyLocationClass obj) {
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testLocationOfNonExistingURL(@Location MyPageObjectWrongURL obj) {
+    }
+
+    /*
+     * Nested classes
+     */
+
+    @Location("org/jboss/arquillian/graphene/ftest/enricher/sample.html")
+    public static class MyPageObject1 {
+        @FindBy(css = "#pseudoroot")
+        WebElement element;
+    }
+
+    @Location("org/jboss/arquillian/graphene/ftest/enricher/empty-findby.html")
+    public static class MyPageObject2 {
+        @FindBy(css = "#divWebElement")
+        WebElement element;
+    }
+
+    @Location
+    public static class MyPageObjectEmptyLocationClass {
+
+    }
+
+    @Location("/non/existing/url")
+    public static class MyPageObjectWrongURL {
+
+    }
+}

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/pages/AbstractPage.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/pages/AbstractPage.java
@@ -1,4 +1,4 @@
-package org.jboss.arquillian.graphene.enricher.page;
+package org.jboss.arquillian.graphene.enricher.pageObjects.pages;
 
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/pages/EmbeddedPage.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/pages/EmbeddedPage.java
@@ -1,4 +1,4 @@
-package org.jboss.arquillian.graphene.enricher.page;
+package org.jboss.arquillian.graphene.enricher.pageObjects.pages;
 
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/pages/TestPage.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/pages/TestPage.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.arquillian.graphene.enricher.page;
+package org.jboss.arquillian.graphene.enricher.pageObjects.pages;
 
 import java.util.List;
 

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/pages/TestPage2.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/enricher/pageObjects/pages/TestPage2.java
@@ -1,4 +1,4 @@
-package org.jboss.arquillian.graphene.enricher.page;
+package org.jboss.arquillian.graphene.enricher.pageObjects.pages;
 
 import org.jboss.arquillian.graphene.enricher.fragment.AbstractPageFragmentStub;
 import org.jboss.arquillian.graphene.spi.annotations.Page;

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/GrapheneEnricher.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/GrapheneEnricher.java
@@ -21,12 +21,17 @@
  */
 package org.jboss.arquillian.graphene.enricher;
 
-import org.jboss.arquillian.graphene.spi.enricher.SearchContextTestEnricher;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.spi.ServiceLoader;
 import org.jboss.arquillian.graphene.context.GrapheneContext;
+import org.jboss.arquillian.graphene.spi.annotations.Location;
+import org.jboss.arquillian.graphene.spi.enricher.SearchContextTestEnricher;
 import org.jboss.arquillian.test.spi.TestEnricher;
 import org.openqa.selenium.WebDriver;
 
@@ -41,18 +46,87 @@ public class GrapheneEnricher implements TestEnricher {
 
     @Inject
     private Instance<ServiceLoader> serviceLoader;
-
+    
     @Override
     public void enrich(Object o) {
         final WebDriver driver = GrapheneContext.getProxy();
-        for (SearchContextTestEnricher enricher: serviceLoader.get().all(SearchContextTestEnricher.class)) {
+        for (SearchContextTestEnricher enricher : serviceLoader.get().all(SearchContextTestEnricher.class)) {
             enricher.enrich(driver, o);
         }
     }
 
     @Override
     public Object[] resolve(Method method) {
+        processLocationAnnotation(method);
+
         return new Object[method.getParameterTypes().length];
     }
 
+    /**
+     * If method contains </code>@Location</code> over any of the parameters, it will open the page in the browser.
+     * @param method
+     * @throws IllegalArgumentException when the <code>@Location</code> annotation over parameter 
+     * type is either empty or it points to the non existing URL or together with <code>contextRoot</code> 
+     * returned by Arquillian an <code>MalformedURLException</code>.     
+    */
+    private void processLocationAnnotation(Method method) {
+        //on the index of Location annotation will be stored also the parameter type
+        int index = getIndexOfParameterWithAnnotation(Location.class, method);
+
+        Class<?> parameterType = method.getParameterTypes()[index];
+        String locationValue = parameterType.getAnnotation(Location.class).value();
+        if (locationValue.length() == 0) {
+            throw new IllegalArgumentException("The @Location value over: " + parameterType
+                    + " should be a URL of the page which the page object represents. Can not be empty!");
+        }
+        URL contextRoot = null; //need to get contextRoot somehow
+        if (contextRoot == null) {
+            //there is no deployment
+            URL url = this.getClass().getClassLoader().getResource(locationValue);
+            if (url == null) {
+                throw new IllegalArgumentException("Graphene is trying to open: " + locationValue
+                        + " as a local resource as it seems that you are not deploying on any container and "
+                        + "the resource does not exist. Check out the @Location value over: " + parameterType);
+            }
+            GrapheneContext.getProxy().get(url.toExternalForm());
+        } else {
+            try {
+                GrapheneContext.getProxy().get(new URL(contextRoot, locationValue).toExternalForm());
+            } catch (MalformedURLException e) {
+                throw new IllegalArgumentException("Graphene is trying to open: " + contextRoot.toExternalForm()
+                        + locationValue + ". However there was an error! Check out @Location value over: " + parameterType, 
+                        e);
+            }
+        }
+    }
+
+    /**
+     * Returns the index of the first parameter which contains the <code>annotation</code>
+     * @param annotation
+     * @param method
+     * @return
+     */
+    private int getIndexOfParameterWithAnnotation(Class<? extends Annotation> annotation, Method method) {
+        Annotation[][] annotationsOfAllParameters = method.getParameterAnnotations();
+
+        int result = 0;
+        boolean founded = false;
+        for (; result < annotationsOfAllParameters.length; result++) {
+            for (int j = 0; j < annotationsOfAllParameters[result].length; j++) {
+                if (annotationsOfAllParameters[result][j].annotationType().equals(annotation)) {
+                    founded = true;
+                    break;
+                }
+            }
+            if (founded) {
+                break;
+            }
+        }
+        if (!founded) {
+            //the method has no parameters with Location annotation
+            return -1;
+        }
+
+        return result;
+    }
 }

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/PageObjectEnricher.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/PageObjectEnricher.java
@@ -27,9 +27,11 @@ import java.lang.reflect.TypeVariable;
 import java.util.List;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.core.spi.ServiceLoader;
 import org.jboss.arquillian.graphene.enricher.exception.PageObjectInitializationException;
 import org.jboss.arquillian.graphene.spi.annotations.Page;
+import org.jboss.arquillian.test.spi.event.suite.Before;
 import org.openqa.selenium.SearchContext;
 
 /**
@@ -62,7 +64,8 @@ public class PageObjectEnricher extends AbstractSearchContextEnricher {
                 }
 
                 errorMsgBegin = "Can not instantiate Page Object " + NEW_LINE + declaredClass + NEW_LINE
-                    + " declared in: " + NEW_LINE + target.getClass().getName() + NEW_LINE;
+                    + " declared in: "
+                        + NEW_LINE + target.getClass().getName() + NEW_LINE;
 
                 Object page = instantiate(declaredClass);
 
@@ -83,5 +86,9 @@ public class PageObjectEnricher extends AbstractSearchContextEnricher {
             }
 
         }
+    }
+
+    public void loadPageObjectWithLocation(@Observes Before event) {
+        System.out.println("################################################# Haloooooooooooooooo!");
     }
 }

--- a/graphene-webdriver/graphene-webdriver-spi/src/main/java/org/jboss/arquillian/graphene/spi/annotations/Location.java
+++ b/graphene-webdriver/graphene-webdriver-spi/src/main/java/org/jboss/arquillian/graphene/spi/annotations/Location.java
@@ -1,0 +1,13 @@
+package org.jboss.arquillian.graphene.spi.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.PARAMETER})
+public @interface Location {
+
+    String value() default "";
+}


### PR DESCRIPTION
It is not intended to be merged.
- I quite stuck with how to get `@ArquillianResource contextRoot` being injected to `GrapheneEnricher`
  https://github.com/jhuska/arquillian-graphene/blob/ARQGRA-197/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/GrapheneEnricher.java
- I thought of something like: `public void testFoo(@Location MyPageObject obj, @ArquillianResource URL contextRoot, @MyBrowserQualifier Webdriver webdriver)` to denote the `contextRoot` and the browser which will be used. However, it is quite verbose.

Thanks!
