### PR TITLE
ARQGRA-264: @InFrame functionality support added

### DIFF
--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/TestInFrameFunctionality.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/TestInFrameFunctionality.java
@@ -1,0 +1,282 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, Red Hat, Inc. and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.graphene.ftest.enricher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.enricher.findby.FindBy;
+import org.jboss.arquillian.graphene.ftest.Resource;
+import org.jboss.arquillian.graphene.ftest.Resources;
+import org.jboss.arquillian.graphene.ftest.enricher.page.PageWithIFrames;
+import org.jboss.arquillian.graphene.ftest.enricher.page.PageWithIFrames2;
+import org.jboss.arquillian.graphene.ftest.enricher.page.fragment.PageFragmentWithSpan;
+import org.jboss.arquillian.graphene.spi.annotations.InFrame;
+import org.jboss.arquillian.graphene.spi.annotations.Page;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import qualifier.Browser1;
+import qualifier.Browser2;
+
+/**
+ * @author <a href="mailto:jhuska@redhat.com">Juraj Huska</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class TestInFrameFunctionality {
+
+    @Drone
+    private WebDriver browser;
+
+    @Page
+    private PageWithIFrames page;
+
+    @Page
+    @InFrame(index = 0)
+    private PageWithIFrames2 page2;
+
+    @InFrame(nameOrId = "second")
+    @FindBy(id = "root")
+    private PageFragmentWithSpan myFragment;
+
+    @InFrame(index = 0)
+    @FindBy(tagName = "span")
+    private WebElement span;
+
+    @FindBy(className = "divElement")
+    private WebElement elementInDefaultFrame;
+    
+    @Browser1
+    @Drone
+    protected WebDriver browser1;
+
+    @Browser2
+    @Drone
+    protected WebDriver browser2;
+    
+    @Browser2
+    @Page
+    private PageWithIFrames pageMultipleBrowsers;
+
+    @Browser1
+    @Page
+    @InFrame(index = 0)
+    private PageWithIFrames2 page2MultipleBrowsers;
+
+    @Browser2
+    @InFrame(nameOrId = "second")
+    @FindBy(id = "root")
+    private PageFragmentWithSpan myFragmentMultipleBrowsers;
+
+    @Browser1
+    @InFrame(index = 0)
+    @FindBy(tagName = "span")
+    private WebElement spanMultipleBrowsers;
+
+    @Browser2
+    @FindBy(className = "divElement")
+    private WebElement elementInDefaultFrameMultipleBrowsers;
+    
+    @ArquillianResource
+    private URL contextRoot;
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return Resources.inCurrentPackage().all().buildWar("test.war");
+    }
+
+    @Before
+    public void loadPage() {
+        loadTheRightPage(browser);
+        loadTheRightPage(browser1);
+        loadTheRightPage(browser2);
+    }
+    
+    private void loadTheRightPage(WebDriver browser) {
+        Resource.inCurrentPackage().find("inframe.html").loadPage(browser, contextRoot);
+    }
+
+    private static final String EXPECTED_WEB_ELEMENT_IN_FRAME_TEXT = "not correct";
+    private static final String EXPECTED_WEB_ELEMENT_OUTSIDE_IFRAME_TEXT = "Outsider div element";
+    private static final String EXPECTED_SELECT_FIRST_OPTION_TEXT = "option one";
+
+    @Test
+    public void testWebElementInFrameDefinedByIndex() {
+        checkWebElementInFrame(page.getSpan());
+    }
+
+    @Test
+    public void testInFrameOverPageObject1() {
+        checkWebElementInFrame(page2.getSpan());
+    }
+    
+    @Test
+    public void testInFrameOverPageObjectMultipleBrowsers() {
+        Resources.inCurrentPackage();
+        checkWebElementInFrame(page2MultipleBrowsers.getSpan());
+    }
+
+    @Test
+    public void testWebElementInFrameDeclaredInTest() {
+        checkWebElementInFrame(span);
+    }
+    
+    @Test
+    public void testWebElementInFrameDeclaredInTestMultipleBrowsers() {
+        checkWebElementInFrame(spanMultipleBrowsers);
+    }
+
+    @Test
+    public void testPageFragmentInFrameDefinedById() {
+        checkPageFragmentInFrame(page.getMyFragment());
+    }
+    
+    @Test
+    public void testPageFragmentInFrameDefinedByIdMultipleBrowsers() {
+        checkPageFragmentInFrame(pageMultipleBrowsers.getMyFragment());
+    }
+
+    @Test
+    public void testPageFragmentInFrameDeclaredInTest() {
+        checkPageFragmentInFrame(myFragment);
+    }
+    
+    @Test
+    public void testPageFragmentInFrameDeclaredInTestMultipleBrowsers() {
+        checkPageFragmentInFrame(myFragmentMultipleBrowsers);
+    }
+
+    @Test
+    public void testSelectInFrameDefinedByName() {
+        List<WebElement> options = page.getSelect().getOptions();
+        assertEquals(3, options.size());
+        assertEquals(EXPECTED_SELECT_FIRST_OPTION_TEXT, options.get(0).getText());
+    }
+    
+    @Test
+    public void testSelectInFrameDefinedByNameMultipleBrowsers() {
+        List<WebElement> options = pageMultipleBrowsers.getSelect().getOptions();
+        assertEquals(3, options.size());
+        assertEquals(EXPECTED_SELECT_FIRST_OPTION_TEXT, options.get(0).getText());
+    }
+    
+    @Test
+    public void testInFrameOverPageObject2() {
+        List<WebElement> options = page2.getSelect().getOptions();
+        assertEquals(3, options.size());
+        assertEquals(EXPECTED_SELECT_FIRST_OPTION_TEXT, options.get(0).getText());
+    }
+    
+    @Test
+    public void testInFrameOverPageObject2MultipleBrowsers() {
+        List<WebElement> options = page2MultipleBrowsers.getSelect().getOptions();
+        assertEquals(3, options.size());
+        assertEquals(EXPECTED_SELECT_FIRST_OPTION_TEXT, options.get(0).getText());
+    }
+
+    @Test
+    public void testElementInDefaultFrame() {
+        checkWebElementInDefaultFrame(page.getElementInDefaultFrame());
+    }
+    
+    @Test
+    public void testElementInDefaultFrameMultipleBrowsers() {
+        checkWebElementInDefaultFrame(pageMultipleBrowsers.getElementInDefaultFrame());
+    }
+
+    @Test
+    public void testElementInDefaultFrameDeclaredInTest() {
+        checkWebElementInDefaultFrame(elementInDefaultFrame);
+    }
+    
+    @Test
+    public void testElementInDefaultFrameDeclaredInTestMultipleBrowsers() {
+        checkWebElementInDefaultFrame(elementInDefaultFrameMultipleBrowsers);
+    }
+
+    @Test
+    public void testPageFragmenInFrameMoreComplexInteractions() {
+        List<WebElement> spans = page.getMyFragment().getSpans();
+        WebElement span = page.getMyFragment().getSpan();
+        checkPageFragmentInFrame(page.getMyFragment());
+
+        checkWebElementInDefaultFrame(page.getElementInDefaultFrame());
+
+        String spanText = span.getText();
+        assertEquals("1", spanText);
+        int sizeOfList = spans.size();
+        assertEquals(4, sizeOfList);
+
+        for (int i = 0; i < sizeOfList; i++) {
+            String text = page.getMyFragment().getSpans().get(i).getText();
+            assertTrue(!text.contains("fail"));
+            assertEquals(Integer.valueOf(i + 1), Integer.valueOf(text.trim()));
+        }
+    }
+
+    @Test
+    public void testMoreComplexInteractingWithInFrameElements() {
+        checkWebElementInFrame(page.getSpan());
+        checkWebElementInFrame(page.getSpan());
+
+        WebElement element = browser.findElement(By.className("divElement"));
+        checkWebElementInDefaultFrame(element);
+
+        checkPageFragmentInFrame(page.getMyFragment());
+    }
+
+    private void checkPageFragmentInFrame(PageFragmentWithSpan fragment) {
+        List<WebElement> spans = fragment.getSpans();
+        int sizeOfList = spans.size();
+        assertEquals(4, sizeOfList);
+
+        for (int i = 0; i < sizeOfList; i++) {
+            String text = fragment.getSpans().get(i).getText();
+            assertTrue(!text.contains("fail"));
+            assertEquals(Integer.valueOf(i + 1), Integer.valueOf(text.trim()));
+        }
+    }
+
+    private void checkWebElementInFrame(WebElement element) {
+        String text = element.getText();
+        assertEquals(EXPECTED_WEB_ELEMENT_IN_FRAME_TEXT, text);
+    }
+
+    private void checkWebElementInDefaultFrame(WebElement element) {
+        testWebElementInFrameDefinedByIndex();
+        assertEquals(EXPECTED_WEB_ELEMENT_OUTSIDE_IFRAME_TEXT, page.getElementInDefaultFrame().getText());
+    }
+}

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/page/PageWithIFrames.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/page/PageWithIFrames.java
@@ -1,0 +1,46 @@
+package org.jboss.arquillian.graphene.ftest.enricher.page;
+
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.enricher.findby.FindBy;
+import org.jboss.arquillian.graphene.ftest.enricher.page.fragment.PageFragmentWithSpan;
+import org.jboss.arquillian.graphene.spi.annotations.InFrame;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
+
+public class PageWithIFrames {
+
+    @InFrame(nameOrId = "first")
+    @FindBy(tagName = "select")
+    private Select select;
+
+    @InFrame(nameOrId = "second")
+    @FindBy(id = "root")
+    private PageFragmentWithSpan myFragment;
+
+    @InFrame(index = 0)
+    @FindBy(tagName = "span")
+    private WebElement span;
+
+    @FindBy(className = "divElement")
+    private WebElement elementInDefaultFrame;
+    
+    @Drone
+    private WebDriver browser;
+
+    public Select getSelect() {
+        return select;
+    }
+
+    public PageFragmentWithSpan getMyFragment() {
+        return myFragment;
+    }
+
+    public WebElement getSpan() {
+        return span;
+    }
+
+    public WebElement getElementInDefaultFrame() {
+        return elementInDefaultFrame;
+    }
+}

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/page/PageWithIFrames2.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/page/PageWithIFrames2.java
@@ -1,0 +1,27 @@
+package org.jboss.arquillian.graphene.ftest.enricher.page;
+
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.enricher.findby.FindBy;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
+
+public class PageWithIFrames2 {
+
+    @FindBy(tagName = "select")
+    private Select select;
+
+    @FindBy(tagName = "span")
+    private WebElement span;
+
+    @Drone
+    private WebDriver browser;
+
+    public Select getSelect() {
+        return select;
+    }
+
+    public WebElement getSpan() {
+        return span;
+    }
+}

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/page/fragment/PageFragmentWithSpan.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/page/fragment/PageFragmentWithSpan.java
@@ -1,0 +1,31 @@
+package org.jboss.arquillian.graphene.ftest.enricher.page.fragment;
+
+import java.util.List;
+
+import org.jboss.arquillian.graphene.enricher.findby.FindBy;
+import org.openqa.selenium.WebElement;
+
+public class PageFragmentWithSpan {
+
+    @FindBy(tagName = "span")
+    private List<WebElement> spans;
+    
+    @FindBy(tagName = "span")
+    private WebElement span;
+
+    public List<WebElement> getSpans() {
+        return spans;
+    }
+
+    public void setSpans(List<WebElement> spans) {
+        this.spans = spans;
+    }
+
+    public WebElement getSpan() {
+        return span;
+    }
+
+    public void setSpan(WebElement span) {
+        this.span = span;
+    }
+}

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/resources/org/jboss/arquillian/graphene/ftest/enricher/inframe.html
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/resources/org/jboss/arquillian/graphene/ftest/enricher/inframe.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+	<div class="divElement">Outsider div element</div>
+	<iframe src="sample.html" name="first">
+		<span>Your browser does not support iframes!</span>
+	</iframe>
+	<iframe src="morepagefragments.html" id="second">
+		<span>Your browser does not support iframes!</span>
+	</iframe>
+</body>
+</html>

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/GrapheneExtension.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/GrapheneExtension.java
@@ -27,6 +27,7 @@ import org.jboss.arquillian.graphene.configuration.GrapheneConfigurationResource
 import org.jboss.arquillian.graphene.configuration.GrapheneConfigurator;
 import org.jboss.arquillian.graphene.enricher.GrapheneContextProvider;
 import org.jboss.arquillian.graphene.enricher.GrapheneEnricher;
+import org.jboss.arquillian.graphene.enricher.InFrameEnricher;
 import org.jboss.arquillian.graphene.enricher.JavaScriptEnricher;
 import org.jboss.arquillian.graphene.enricher.PageFragmentEnricher;
 import org.jboss.arquillian.graphene.enricher.PageObjectEnricher;
@@ -56,6 +57,7 @@ public class GrapheneExtension implements LoadableExtension {
         builder.service(SearchContextTestEnricher.class, PageObjectEnricher.class);
         builder.service(SearchContextTestEnricher.class, WebElementWrapperEnricher.class);
         builder.service(SearchContextTestEnricher.class, FieldAccessValidatorEnricher.class);
+        builder.service(SearchContextTestEnricher.class, InFrameEnricher.class);
         /** Javascript enrichment */
         builder.service(SearchContextTestEnricher.class, JavaScriptEnricher.class);
         /* Resource Providers */

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/FieldAccessValidatorEnricher.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/FieldAccessValidatorEnricher.java
@@ -58,4 +58,9 @@ public class FieldAccessValidatorEnricher implements SearchContextTestEnricher {
             }
         }
     }
+
+    @Override
+    public int getPrecedence() {
+        return 1;
+    }
 }

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/GrapheneEnricher.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/GrapheneEnricher.java
@@ -21,28 +21,28 @@
  */
 package org.jboss.arquillian.graphene.enricher;
 
-import org.jboss.arquillian.graphene.spi.enricher.SearchContextTestEnricher;
 import java.lang.reflect.Method;
+
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.spi.ServiceLoader;
+import org.jboss.arquillian.graphene.spi.enricher.SearchContextTestEnricher;
 import org.jboss.arquillian.test.spi.TestEnricher;
 
 /**
- * Graphene enricher calls all {@link SearchContextTestEnricher} instances to start
- * their enrichment.
- *
+ * Graphene enricher calls all {@link SearchContextTestEnricher} instances to start their enrichment.
+ * 
  * @author <a href="mailto:jhuska@redhat.com">Juraj Huska</a>
  * @author <a href="mailto:jpapouse@redhat.com">Jan Papousek</a>
  */
 public class GrapheneEnricher implements TestEnricher {
 
     @Inject
-    private Instance<ServiceLoader> serviceLoader;
+    private static Instance<ServiceLoader> serviceLoader;
 
     @Override
     public void enrich(Object o) {
-        for (SearchContextTestEnricher enricher: serviceLoader.get().all(SearchContextTestEnricher.class)) {
+        for (SearchContextTestEnricher enricher : AbstractSearchContextEnricher.getSortedSearchContextEnrichers(serviceLoader)) {
             enricher.enrich(null, o);
         }
     }
@@ -51,5 +51,4 @@ public class GrapheneEnricher implements TestEnricher {
     public Object[] resolve(Method method) {
         return new Object[method.getParameterTypes().length];
     }
-
 }

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/InFrameEnricher.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/InFrameEnricher.java
@@ -1,0 +1,106 @@
+package org.jboss.arquillian.graphene.enricher;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.arquillian.graphene.enricher.exception.GrapheneTestEnricherException;
+import org.jboss.arquillian.graphene.enricher.findby.FindBy;
+import org.jboss.arquillian.graphene.proxy.GrapheneProxyInstance;
+import org.jboss.arquillian.graphene.spi.annotations.InFrame;
+import org.jboss.arquillian.graphene.spi.annotations.Page;
+import org.openqa.selenium.SearchContext;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
+
+public class InFrameEnricher extends AbstractSearchContextEnricher {
+
+    private final Set<Class<?>> DO_NOT_ENRICH_FURTHER = new HashSet<Class<?>>(Arrays.asList(new Class<?>[] { WebElement.class,
+            Select.class, List.class, WebDriver.class }));
+
+    @Override
+    public void enrich(SearchContext searchContext, Object objectToEnrich) {
+        Collection<Field> inFrameFields = ReflectionHelper.getFieldsWithAnnotation(objectToEnrich.getClass(), InFrame.class);
+        for (Field field : inFrameFields) {
+            boolean isAccessible = field.isAccessible();
+            if (!isAccessible) {
+                field.setAccessible(true);
+            }
+            InFrame inFrame = field.getAnnotation(InFrame.class);
+            int index = inFrame.index();
+            String nameOrId = inFrame.nameOrId();
+            checkInFrameParameters(field, index, nameOrId);
+
+            try {
+                registerInFrameInterceptor(objectToEnrich, field, index, nameOrId);
+            } catch (IllegalArgumentException e) {
+                throw new GrapheneTestEnricherException(
+                    "Only org.openqa.selenium.WebElement, Page fragments fields and Page Object fields can be annotated with @InFrame. Check the field: "
+                        + field + " declared in the class: " + objectToEnrich.getClass(), e);
+            } catch (Exception e) {
+                throw new GrapheneTestEnricherException(e);
+            }
+            if (!isAccessible) {
+                field.setAccessible(false);
+            }
+        }
+    }
+
+    private void registerInFrameInterceptor(Object objectToEnrich, Field field, int index, String nameOrId)
+        throws IllegalAccessException, ClassNotFoundException {
+        GrapheneProxyInstance proxy = (GrapheneProxyInstance) field.get(objectToEnrich);
+
+        Class<?> fieldType = field.getType();
+        if (index != -1) {
+            proxy.registerInterceptor(new InFrameInterceptor(index));
+        } else {
+            proxy.registerInterceptor(new InFrameInterceptor(nameOrId));
+        }
+        if (!DO_NOT_ENRICH_FURTHER.contains(fieldType)) {
+            enrichRecursivelyGrapheneProxyInstances(proxy, nameOrId, index, field);
+            enrichRecursivelyGrapheneProxyInstances(proxy.unwrap(), nameOrId, index, field);
+        }
+    }
+
+    private void enrichRecursivelyGrapheneProxyInstances(Object objectToEnrich, String nameOrId, int index, Field field)
+        throws ClassNotFoundException, IllegalArgumentException, IllegalAccessException {
+        enrichFurtherSpecificAnnotation(objectToEnrich, nameOrId, index, FindBy.class, field);
+        enrichFurtherSpecificAnnotation(objectToEnrich, nameOrId, index, org.openqa.selenium.support.FindBy.class, field);
+        enrichFurtherSpecificAnnotation(objectToEnrich, nameOrId, index, Page.class, field);
+    }
+
+    private void enrichFurtherSpecificAnnotation(Object objectToEnrich, String nameOrId, int index,
+        final Class<? extends Annotation> annotationClass, Field field) throws ClassNotFoundException,
+        IllegalArgumentException, IllegalAccessException {
+        Class<?> fieldType = field.getType();
+        List<Field> fieldsToEnrich = ReflectionHelper.getFieldsWithAnnotation(fieldType, annotationClass);
+        for (Field fieldToEnrich : fieldsToEnrich) {
+            boolean isAccessible = field.isAccessible();
+            if (!isAccessible) {
+                fieldToEnrich.setAccessible(true);
+            }
+            registerInFrameInterceptor(objectToEnrich, fieldToEnrich, index, nameOrId);
+            if (!isAccessible) {
+                field.setAccessible(false);
+            }
+        }
+    }
+
+    private void checkInFrameParameters(Field field, int index, String nameOrId) {
+        if ((nameOrId.trim().equals("") && index < 0)) {
+            throw new GrapheneTestEnricherException(
+                "You have to provide either non empty nameOrId or non negative index value of the frame/iframe in the @InFrame. Check field "
+                    + field + " declared in: " + field.getDeclaringClass());
+        }
+    }
+
+    @Override
+    public int getPrecedence() {
+        return 0;
+    }
+}

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/InFrameInterceptor.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/InFrameInterceptor.java
@@ -1,0 +1,46 @@
+package org.jboss.arquillian.graphene.enricher;
+
+import org.jboss.arquillian.graphene.proxy.GrapheneProxyInstance;
+import org.jboss.arquillian.graphene.proxy.Interceptor;
+import org.jboss.arquillian.graphene.proxy.InvocationContext;
+import org.openqa.selenium.WebDriver;
+
+public class InFrameInterceptor implements Interceptor {
+
+    private int indexOfFrame = -1;
+    private String nameOrIdOfFrame = null;
+
+    public InFrameInterceptor(String nameOrIdOfFrame) {
+        if (nameOrIdOfFrame == null || nameOrIdOfFrame.length() == 0) {
+            throw new IllegalArgumentException("nameOrIdOfFrame can not be null or an empty string!");
+        }
+        this.nameOrIdOfFrame = nameOrIdOfFrame;
+    }
+
+    public InFrameInterceptor(int indexOfFrame) {
+        if (indexOfFrame < 0) {
+            throw new IllegalArgumentException("indexOfFrame can not be less than zero!");
+        }
+        this.indexOfFrame = indexOfFrame;
+    }
+
+    @Override
+    public Object intercept(InvocationContext context) throws Throwable {
+        WebDriver browser = context.getGrapheneContext().getWebDriver();
+        if (indexOfFrame != -1) {
+            browser.switchTo().frame(indexOfFrame);
+        } else if (nameOrIdOfFrame != null) {
+            browser.switchTo().frame(nameOrIdOfFrame);
+        }
+        Object result = null;
+        try {
+            result = context.invoke();
+        } finally {
+            browser.switchTo().defaultContent();
+        }
+        if (result instanceof GrapheneProxyInstance) {
+            ((GrapheneProxyInstance) result).registerInterceptor(this);
+        }
+        return result;
+    }
+}

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/JavaScriptEnricher.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/JavaScriptEnricher.java
@@ -53,4 +53,9 @@ public class JavaScriptEnricher extends AbstractSearchContextEnricher {
             }
         }
     }
+
+    @Override
+    public int getPrecedence() {
+        return 1;
+    }
 }

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/PageFragmentEnricher.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/PageFragmentEnricher.java
@@ -173,4 +173,9 @@ public class PageFragmentEnricher extends AbstractSearchContextEnricher {
         Object pageFragment = createPageFragment(field.getType(), root);
         setValue(field, target, pageFragment);
     }
+
+    @Override
+    public int getPrecedence() {
+        return 1;
+    }
 }

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/PageObjectEnricher.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/PageObjectEnricher.java
@@ -96,4 +96,9 @@ public class PageObjectEnricher extends AbstractSearchContextEnricher {
         enrichRecursively(searchContext, proxy); // because of possibility of direct access to attributes from test class
         return proxy;
     }
+
+    @Override
+    public int getPrecedence() {
+        return 1;
+    }
 }

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/SearchContextTestEnricherPrecedenceComparator.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/SearchContextTestEnricherPrecedenceComparator.java
@@ -1,0 +1,20 @@
+package org.jboss.arquillian.graphene.enricher;
+
+import java.util.Comparator;
+
+import org.jboss.arquillian.graphene.spi.enricher.SearchContextTestEnricher;
+
+public class SearchContextTestEnricherPrecedenceComparator implements Comparator<SearchContextTestEnricher> {
+
+    @Override
+    public int compare(SearchContextTestEnricher o1, SearchContextTestEnricher o2) {
+        if (o1.getPrecedence() > o2.getPrecedence()) {
+            return -1;
+        } else if (o1.getPrecedence() < o2.getPrecedence()) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+
+}

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/WebElementEnricher.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/WebElementEnricher.java
@@ -81,4 +81,9 @@ public class WebElementEnricher extends AbstractSearchContextEnricher {
             throw new IllegalStateException(e.getMessage(), e);
         }
     }
+
+    @Override
+    public int getPrecedence() {
+        return 1;
+    }
 }

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/WebElementUtils.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/WebElementUtils.java
@@ -25,9 +25,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.jboss.arquillian.graphene.GrapheneContext;
 import org.jboss.arquillian.graphene.enricher.findby.ByJQuery;
-
 import org.jboss.arquillian.graphene.intercept.InterceptorBuilder;
 import org.jboss.arquillian.graphene.proxy.GrapheneProxy;
 import org.jboss.arquillian.graphene.proxy.GrapheneProxyHandler;

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/WebElementWrapperEnricher.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/WebElementWrapperEnricher.java
@@ -124,4 +124,9 @@ public class WebElementWrapperEnricher extends AbstractSearchContextEnricher {
             return ReflectionHelper.hasConstructor(clazz, outerClass, WebElement.class);
         }
     }
+
+    @Override
+    public int getPrecedence() {
+        return 1;
+    }
 }

--- a/graphene-webdriver/graphene-webdriver-spi/src/main/java/org/jboss/arquillian/graphene/spi/annotations/InFrame.java
+++ b/graphene-webdriver/graphene-webdriver-spi/src/main/java/org/jboss/arquillian/graphene/spi/annotations/InFrame.java
@@ -1,0 +1,15 @@
+package org.jboss.arquillian.graphene.spi.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface InFrame {
+    
+    String nameOrId() default "";
+    
+    int index() default -1;
+}

--- a/graphene-webdriver/graphene-webdriver-spi/src/main/java/org/jboss/arquillian/graphene/spi/enricher/SearchContextTestEnricher.java
+++ b/graphene-webdriver/graphene-webdriver-spi/src/main/java/org/jboss/arquillian/graphene/spi/enricher/SearchContextTestEnricher.java
@@ -39,6 +39,11 @@ public interface SearchContextTestEnricher {
      * @param searchContext the context which should be used for enrichment
      * @param target instance to be enriched
      */
-    public void enrich(SearchContext searchContext, Object target);
-
+    void enrich(SearchContext searchContext, Object target);
+    
+    /**
+     * Returns the enricher precedence. Zero precedence is is the lowest one. 
+     * @return
+     */
+    int getPrecedence();
 }


### PR DESCRIPTION
- Page Objects, Page Fragments, WebElements and other elements can now
  be annotated with @InFrame annotation to denote in what frame it
  should be located
- SearchContextTestEnricher#getPrecendence method added to interface -
  enables to define an order in which the enrichers should be called
- InFrameEnricher and InFrameInterceptor added
- It works in a way that it scans objects for @InFrame annotation. If a
  field has one, then interceptor is registered for the object in this
  field. If the field is either Page Fragment or Page Object then it is enriched
  recursivelly.
- The InFrameInteceptor works in a way that it intercepts all method
  invocations on the object it is registered for and then switches to
  the specified frame, invokes the action and then returnes to the default
  frame together with returining the result of the method invocation
