### PR TITLE
ARQGRA-224: page fragments implementing WebElement interface delegate

### DIFF
--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/TestPageFragmentDelegatingToWebElement.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/TestPageFragmentDelegatingToWebElement.java
@@ -1,0 +1,70 @@
+package org.jboss.arquillian.graphene.ftest.enricher;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.ftest.Resources;
+import org.jboss.arquillian.graphene.ftest.enricher.page.fragment.PageFragmentImplementingWebElement;
+import org.jboss.arquillian.graphene.spi.annotations.InitialPage;
+import org.jboss.arquillian.graphene.spi.annotations.Location;
+import org.jboss.arquillian.graphene.spi.annotations.Page;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.FindBy;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class TestPageFragmentDelegatingToWebElement {
+
+    @Drone
+    private WebDriver browser;
+
+    @ArquillianResource
+    private URL contextRoot;
+
+    @Page
+    private TestPage page;
+    
+    private static final String pageLocation = "org/jboss/arquillian/graphene/ftest/enricher/delegating-pagefragment.html";
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return Resources.inCurrentPackage().find("delegating-pagefragment.html").buildWar("deployment.war");
+    }
+
+    @Test
+    public void testPageFragmentMethodIsDelegatingCorrectly() {
+        browser.get(contextRoot + pageLocation);
+        testPage(page);
+    }
+    
+    @Test
+    public void testPageFragmentFromInitialPageIsDelegatingCorrectly(@InitialPage TestPage testedPage) {
+        testPage(testedPage);
+    }
+    
+    private void testPage(TestPage testedPage) {
+        String expectedText = "test";
+        testedPage.getInputFragment().sendKeys(expectedText);
+        assertEquals(expectedText, testedPage.getInputFragment().getInputText());
+        assertEquals("foo-bar", testedPage.getInputFragment().getStyleClass());
+    }
+
+    @Location("resource://" + pageLocation)
+    public class TestPage {
+        @FindBy(tagName = "input")
+        private PageFragmentImplementingWebElement inputFragment;
+
+        public PageFragmentImplementingWebElement getInputFragment() {
+            return inputFragment;
+        }
+    }
+}

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/page/fragment/PageFragmentImplementingWebElement.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/page/fragment/PageFragmentImplementingWebElement.java
@@ -1,0 +1,18 @@
+package org.jboss.arquillian.graphene.ftest.enricher.page.fragment;
+
+import org.jboss.arquillian.graphene.spi.annotations.Root;
+import org.openqa.selenium.WebElement;
+
+public abstract class PageFragmentImplementingWebElement implements WebElement {
+
+    @Root
+    private WebElement input;
+    
+    public String getInputText() {
+        return input.getAttribute("value");
+    }
+    
+    public String getStyleClass() {
+        return input.getAttribute("class");
+    }
+}

--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/resources/org/jboss/arquillian/graphene/ftest/enricher/delegating-pagefragment.html
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/resources/org/jboss/arquillian/graphene/ftest/enricher/delegating-pagefragment.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style type="text/css">
+.foo-bar {
+	width: 200px;
+	height: 120px;
+}
+</style>
+</head>
+<body>
+	<input class="foo-bar"/>
+</body>
+</html>

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/ClassImposterizer.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/ClassImposterizer.java
@@ -1,0 +1,12 @@
+package org.jboss.arquillian.graphene.enricher;
+
+import net.sf.cglib.proxy.MethodInterceptor;
+
+class ClassImposterizer extends org.jboss.arquillian.graphene.cglib.ClassImposterizer {
+
+    static final ClassImposterizer INSTANCE = new ClassImposterizer();
+
+    <T> T imposterise(MethodInterceptor interceptor, Class<T> mockedType, Class<?>... ancillaryTypes) {
+        return INSTANCE.imposteriseProtected(interceptor, mockedType, ancillaryTypes);
+    }
+}

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/PageObjectEnricher.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/PageObjectEnricher.java
@@ -89,7 +89,7 @@ public class PageObjectEnricher extends AbstractSearchContextEnricher {
         }
     }
 
-    protected <P> P setupPage(GrapheneContext context, SearchContext searchContext, Class<?> pageClass) throws Exception{
+    public static <P> P setupPage(GrapheneContext context, SearchContext searchContext, Class<?> pageClass) throws Exception{
         P page = (P) instantiate(pageClass);
         P proxy = GrapheneProxy.getProxyForHandler(GrapheneProxyHandler.forTarget(context, page), pageClass);
         enrichRecursively(searchContext, page);

--- a/graphene-webdriver/graphene-webdriver-impl/src/test/java/org/jboss/arquillian/graphene/enricher/TestPageFragmentEnricher.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/test/java/org/jboss/arquillian/graphene/enricher/TestPageFragmentEnricher.java
@@ -42,22 +42,21 @@ public class TestPageFragmentEnricher extends AbstractGrapheneEnricherTest {
         Assert.assertNull(target.pageFragment);
     }
 
-
     @Test
     public void testTooManyRoots() {
         thrown.expect(PageFragmentInitializationException.class);
         getGrapheneEnricher().enrich(new TooManyRootsTest());
     }
 
-    @Test
+    @Test(expected = PageFragmentInitializationException.class)
     public void testAbstractType() {
         AbstractTypeTest target = new AbstractTypeTest();
         getGrapheneEnricher().enrich(target);
-        Assert.assertNull(target.pageFragment);
+        Assert.assertNotNull(target.pageFragment);
     }
 
     public static class NoArgConstructorTest {
-        @FindBy(id="blah")
+        @FindBy(id = "blah")
         private WrongPageFragmentMissingNoArgConstructor pageFragment;
     }
 


### PR DESCRIPTION
interface invocations to Root
- A Page Fragment can be declated asbtract when implementing WebElement
  interface. Then all method invocations on such Page Fragment will be
  intercepted, and those which are from WebElement interface will be
  delegated to the Root of the page Fragment.
- LocationEnricher - the creation of the page object was improved, now
  it is using the method from PageObjectEnricher to do so
- Support for declaring Page Fragment as abstract class not added, cause
  it requires more changes in the code
