### PR TITLE
ARQGRA-327 selenium API changes for selenium 2.35.0

### DIFF
--- a/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/selenium/TestSeleniumResourceProvider.java
+++ b/graphene-webdriver/graphene-webdriver-ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/selenium/TestSeleniumResourceProvider.java
@@ -17,10 +17,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.Mouse;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.interactions.Mouse;
 import org.openqa.selenium.internal.Locatable;
 
 /**

--- a/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/SeleniumResourceProvider.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/main/java/org/jboss/arquillian/graphene/enricher/SeleniumResourceProvider.java
@@ -13,14 +13,9 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.HasCapabilities;
-import org.openqa.selenium.HasInputDevices;
-import org.openqa.selenium.HasTouchScreen;
 import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.Keyboard;
-import org.openqa.selenium.Mouse;
 import org.openqa.selenium.Rotatable;
 import org.openqa.selenium.TakesScreenshot;
-import org.openqa.selenium.TouchScreen;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.html5.ApplicationCache;
 import org.openqa.selenium.html5.BrowserConnection;
@@ -30,6 +25,11 @@ import org.openqa.selenium.html5.LocationContext;
 import org.openqa.selenium.html5.SessionStorage;
 import org.openqa.selenium.html5.WebStorage;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.interactions.HasInputDevices;
+import org.openqa.selenium.interactions.HasTouchScreen;
+import org.openqa.selenium.interactions.Keyboard;
+import org.openqa.selenium.interactions.Mouse;
+import org.openqa.selenium.interactions.TouchScreen;
 
 /**
  * Provides common Selenium objects as Arquillian resources

--- a/graphene-webdriver/graphene-webdriver-impl/src/test/java/org/jboss/arquillian/graphene/TestingDriver.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/test/java/org/jboss/arquillian/graphene/TestingDriver.java
@@ -22,11 +22,11 @@
 package org.jboss.arquillian.graphene;
 
 import org.openqa.selenium.HasCapabilities;
-import org.openqa.selenium.HasInputDevices;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.interactions.HasInputDevices;
 import org.openqa.selenium.internal.FindsByClassName;
 import org.openqa.selenium.internal.FindsByCssSelector;
 import org.openqa.selenium.internal.FindsById;

--- a/graphene-webdriver/graphene-webdriver-impl/src/test/java/org/jboss/arquillian/graphene/TestingDriverStub.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/test/java/org/jboss/arquillian/graphene/TestingDriverStub.java
@@ -26,11 +26,11 @@ import java.util.Set;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.Keyboard;
-import org.openqa.selenium.Mouse;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Keyboard;
+import org.openqa.selenium.interactions.Mouse;
 
 /**
  * @author Lukas Fryc

--- a/graphene-webdriver/graphene-webdriver-impl/src/test/java/org/jboss/arquillian/graphene/enricher/TestSeleniumResourceProvider.java
+++ b/graphene-webdriver/graphene-webdriver-impl/src/test/java/org/jboss/arquillian/graphene/enricher/TestSeleniumResourceProvider.java
@@ -22,14 +22,15 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.openqa.selenium.HasInputDevices;
 import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.Keyboard;
-import org.openqa.selenium.Keys;
-import org.openqa.selenium.Mouse;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.interactions.HasInputDevices;
+import org.openqa.selenium.interactions.Keyboard;
+import org.openqa.selenium.interactions.Mouse;
 import org.openqa.selenium.interactions.internal.Coordinates;
+
+
 
 /**
  * @author Lukas Fryc
@@ -49,12 +50,12 @@ public class TestSeleniumResourceProvider {
             }
 
             @Override
-            public void pressKey(Keys keyToPress) {
+            public void pressKey(CharSequence keyToPress) {
                 throw new UnsupportedOperationException("Not supported yet.");
             }
 
             @Override
-            public void releaseKey(Keys keyToRelease) {
+            public void releaseKey(CharSequence keyToRelease) {
                 throw new UnsupportedOperationException("Not supported yet.");
             }
         });

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <!-- Arquillian -->
         <version.arquillian.core>1.1.1.Final</version.arquillian.core>
         <version.arquillian.drone>1.2.0.Alpha3</version.arquillian.drone>
-        <version.selenium>2.33.0</version.selenium>
+        <version.selenium>2.35.0</version.selenium>
         <version.arquillian.jetty>1.0.0.CR1</version.arquillian.jetty>
 
         <!-- Runtime dependencies -->


### PR DESCRIPTION
Do not merge this in unless you want to update to selenium 2.35.0.  Depends on selenium-bom 2.35.0

Selenium API changes in 2.35.0:

These interfaces have been moved:
org.openqa.selenium.HasInputDevices
org.openqa.selenium.HasTouchScreen
org.openqa.selenium.Keyboard
org.openqa.selenium.Mouse
org.openqa.selenium.TouchScreen;

to:
org.openqa.selenium.interactions.HasInputDevices
org.openqa.selenium.interactions.HasTouchScreen
org.openqa.selenium.interactions.Keyboard
org.openqa.selenium.interactions.Mouse
org.openqa.selenium.interactions.TouchScreen;
