### PR TITLE
ARQGRA-308: Throwing exception when Page Fragment is final class

### DIFF
--- a/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/TestInitializingFinalPageFragments.java
+++ b/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/TestInitializingFinalPageFragments.java
@@ -1,0 +1,84 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.graphene.ftest.enricher;
+
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.Graphene;
+import org.jboss.arquillian.graphene.enricher.exception.PageFragmentInitializationException;
+import org.jboss.arquillian.graphene.ftest.Resource;
+import org.jboss.arquillian.graphene.ftest.Resources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * @author Juraj Huska
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class TestInitializingFinalPageFragments {
+
+    @Drone
+    private WebDriver browser;
+
+    @ArquillianResource
+    private URL contextRoot;
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return Resources.inPackage("org.jboss.arquillian.graphene.ftest.pageFragmentsEnricher").all().buildWar("test.war");
+    }
+
+    @Before
+    public void loadPage() {
+        Resource.inPackage("org.jboss.arquillian.graphene.ftest.pageFragmentsEnricher").find("sample.html")
+            .loadPage(browser, contextRoot);
+    }
+
+    @Test(expected = PageFragmentInitializationException.class)
+    public void testInitializingInnerFinalPageFragment() {
+        InnerFinalPageFragment innerFinalFragment = Graphene.createPageFragment(InnerFinalPageFragment.class,
+            browser.findElement(By.id("rootElement")));
+        System.out.println(innerFinalFragment.getBody().getText());
+    }
+
+    public final class InnerFinalPageFragment {
+
+        @FindBy(tagName = "body")
+        private WebElement body;
+
+        public WebElement getBody() {
+            return body;
+        }
+    }
+}


### PR DESCRIPTION
- it is better to notice an user that Page Fragments can not be declared
  as final classes by throwing an exception than just by injecting
  nothing to the @FindBy injection point
