### PR TITLE
ARQGRA-345: GrapheneElement can not be used as @Root - fixed

### DIFF
--- a/api/src/main/java/org/jboss/arquillian/graphene/GrapheneElement.java
+++ b/api/src/main/java/org/jboss/arquillian/graphene/GrapheneElement.java
@@ -21,46 +21,16 @@
  */
 package org.jboss.arquillian.graphene;
 
-import java.util.LinkedList;
 import java.util.List;
 
 import org.openqa.selenium.By;
-import org.openqa.selenium.Dimension;
 import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.Point;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.internal.Coordinates;
 import org.openqa.selenium.internal.Locatable;
 import org.openqa.selenium.internal.WrapsElement;
 
-/**
- * <p>
- * Interface for Graphene extensions of {@link WebElement}.
- * </p>
- *
- * <p>
- * Following methods are provided over the {@link WebElement} interface:
- * </p>
- *
- * <ul>
- * <li>{@link #isPresent()}</li>
- * <li>{@link #findGrapheneElements(By)}</li>
- * </ul>
- *
- * <p>
- * <b>Important</b>: {@link GrapheneElement} <i>is not intended for extension</i>, do not subclass it. The {@link GrapheneElement} might become abstract class or interface in the future. It can't be final because then it couldn't be proxied by Graphene.
- * </p>
- *
- * @author <a href="mailto:jpapouse@redhat.com">Jan Papousek</a>
- */
-public class GrapheneElement implements WebElement, Locatable, WrapsElement {
-
-    private final WebElement element;
-
-    public GrapheneElement(WebElement element) {
-        this.element = element;
-    }
+public interface GrapheneElement extends WebElement, Locatable, WrapsElement {
 
     /**
      * <p>
@@ -77,14 +47,7 @@ public class GrapheneElement implements WebElement, Locatable, WrapsElement {
      *
      * @return true if this element is present in the page
      */
-    public boolean isPresent() {
-        try {
-            element.isDisplayed();
-            return true;
-        } catch (NoSuchElementException ignored) {
-            return false;
-        }
-    }
+    boolean isPresent();
 
     /**
      * This method is alternative to {@link #findElements(By)}, but it returns list of type {@link GrapheneElement}.
@@ -93,182 +56,14 @@ public class GrapheneElement implements WebElement, Locatable, WrapsElement {
      *
      * @see WebElement#findElement(By)
      */
-    public List<GrapheneElement> findGrapheneElements(By by) {
-        List<GrapheneElement> grapheneElements = new LinkedList<GrapheneElement>();
-        for (WebElement e : element.findElements(by)) {
-            grapheneElements.add(new GrapheneElement(e));
-        }
-        return grapheneElements;
-    }
+    List<GrapheneElement> findGrapheneElements(By by);
 
-    /*
-     * (non-Javadoc)
+    /**
+     * Overriden version of <code>WebElement.findBy()</code> method.
      *
-     * @see org.openqa.selenium.WebElement#click()
-     */
-    @Override
-    public void click() {
-        element.click();
-    }
-
-    /*
-     * (non-Javadoc)
+     * @return GrapheneElement
      *
-     * @see org.openqa.selenium.WebElement#submit()
+     * @see WebElement#findElement(By)
      */
-    @Override
-    public void submit() {
-        element.submit();
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.WebElement#sendKeys(java.lang.CharSequence[])
-     */
-    @Override
-    public void sendKeys(CharSequence... keysToSend) {
-        element.sendKeys(keysToSend);
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.WebElement#clear()
-     */
-    @Override
-    public void clear() {
-        element.clear();
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.WebElement#getTagName()
-     */
-    @Override
-    public String getTagName() {
-        return element.getTagName();
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.WebElement#getAttribute(java.lang.String)
-     */
-    @Override
-    public String getAttribute(String name) {
-        return element.getAttribute(name);
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.WebElement#isSelected()
-     */
-    @Override
-    public boolean isSelected() {
-        return element.isSelected();
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.WebElement#isEnabled()
-     */
-    @Override
-    public boolean isEnabled() {
-        return element.isEnabled();
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.WebElement#getText()
-     */
-    @Override
-    public String getText() {
-        return element.getText();
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.WebElement#findElements(org.openqa.selenium.By)
-     */
-    @Override
-    public List<WebElement> findElements(By by) {
-        return element.findElements(by);
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.WebElement#findElement(org.openqa.selenium.By)
-     */
-    @Override
-    public GrapheneElement findElement(By by) {
-        return new GrapheneElement(element.findElement(by));
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.WebElement#isDisplayed()
-     */
-    @Override
-    public boolean isDisplayed() {
-        return element.isDisplayed();
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.WebElement#getLocation()
-     */
-    @Override
-    public Point getLocation() {
-        return element.getLocation();
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.WebElement#getSize()
-     */
-    @Override
-    public Dimension getSize() {
-        return element.getSize();
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.WebElement#getCssValue(java.lang.String)
-     */
-    @Override
-    public String getCssValue(String propertyName) {
-        return element.getCssValue(propertyName);
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.internal.WrapsElement#getWrappedElement()
-     */
-    @Override
-    public WebElement getWrappedElement() {
-        return element;
-    }
-
-    /*
-     * (non-Javadoc)
-     *
-     * @see org.openqa.selenium.internal.Locatable#getCoordinates()
-     */
-    @Override
-    public Coordinates getCoordinates() {
-        return ((Locatable) element).getCoordinates();
-    }
-
+    GrapheneElement findElement(By by);
 }

--- a/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/issues/ARQGRA269.java
+++ b/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/issues/ARQGRA269.java
@@ -1,0 +1,94 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.graphene.ftest.issues;
+
+import java.net.URL;
+
+import junit.framework.Assert;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.ftest.Resource;
+import org.jboss.arquillian.graphene.ftest.Resources;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * Test for https://issues.jboss.org/browse/ARQGRA-269
+ * @author <a href="mailto:jpapouse@redhat.com">Jan Papousek</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ARQGRA269 {
+
+    @ArquillianResource
+    private URL contextRoot;
+
+    @Drone
+    private WebDriver browser;
+
+    @FindBy(css="h1")
+    private WebElement h1;
+
+    @FindBy(tagName="iframe")
+    private WebElement iframe;
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return Resources.inCurrentPackage().all().buildWar("test.war");
+    }
+
+    @Before
+    public void loadPage() {
+        Resource.inCurrentPackage().find("ARQGRA-269_index.html").loadPage(browser, contextRoot);
+    }
+
+    @Test
+    public void testIframeFromWebDriverFindElement() {
+        WebElement iframe = browser.findElement(By.tagName("iframe"));
+        browser.switchTo().frame(iframe);
+        Assert.assertEquals("Inside of the Frame!!", h1.getText().trim());
+    }
+
+    @Test
+    public void testIframeFromWebElementFindElement() {
+        WebElement iframe = browser.findElement(By.tagName("body")).findElement(By.tagName("iframe"));
+        browser.switchTo().frame(iframe);
+        Assert.assertEquals("Inside of the Frame!!", h1.getText().trim());
+    }
+
+    @Test
+    public void testInjectedIframe() {
+        browser.switchTo().frame(iframe);
+        Assert.assertEquals("Inside of the Frame!!", h1.getText().trim());
+    }
+
+}

--- a/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/issues/ARQGRA345.java
+++ b/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/issues/ARQGRA345.java
@@ -21,13 +21,15 @@
  */
 package org.jboss.arquillian.graphene.ftest.issues;
 
-import java.net.URL;
+import static org.junit.Assert.assertEquals;
 
-import junit.framework.Assert;
+import java.net.URL;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.GrapheneElement;
+import org.jboss.arquillian.graphene.fragment.Root;
 import org.jboss.arquillian.graphene.ftest.Resource;
 import org.jboss.arquillian.graphene.ftest.Resources;
 import org.jboss.arquillian.junit.Arquillian;
@@ -36,18 +38,15 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
 /**
- * Test for https://issues.jboss.org/browse/ARQGRA-269
- * @author <a href="mailto:jpapouse@redhat.com">Jan Papousek</a>
+ * @author <a href="mailto:jhuska@redhat.com">Juraj Huska</a>
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-public class ARQGRA269TestCase {
+public class ARQGRA345 {
 
     @ArquillianResource
     private URL contextRoot;
@@ -55,40 +54,40 @@ public class ARQGRA269TestCase {
     @Drone
     private WebDriver browser;
 
-    @FindBy(css="h1")
-    private WebElement h1;
+    @FindBy(id = "root")
+    private PageFragmentWithGrapheneElementAsRoot fragment;
 
-    @FindBy(tagName="iframe")
-    private WebElement iframe;
+    private static final String SAMPLE_PACKAGE = "org.jboss.arquillian.graphene.ftest.enricher";
 
     @Deployment
     public static WebArchive createTestArchive() {
-        return Resources.inCurrentPackage().all().buildWar("test.war");
+        return Resources.inPackage(SAMPLE_PACKAGE).all().buildWar("test.war");
     }
 
     @Before
     public void loadPage() {
-        Resource.inCurrentPackage().find("ARQGRA-269_index.html").loadPage(browser, contextRoot);
+        Resource.inPackage(SAMPLE_PACKAGE).find("sample.html").loadPage(browser, contextRoot);
     }
 
     @Test
-    public void testIframeFromWebDriverFindElement() {
-        WebElement iframe = browser.findElement(By.tagName("iframe"));
-        browser.switchTo().frame(iframe);
-        Assert.assertEquals("Inside of the Frame!!", h1.getText().trim());
+    public void graphene_element_should_be_able_to_be_used_as_root_of_page_fragment() {
+        assertEquals(fragment.getInnerElement().getText(), "pseudo root");
     }
 
-    @Test
-    public void testIframeFromWebElementFindElement() {
-        WebElement iframe = browser.findElement(By.tagName("body")).findElement(By.tagName("iframe"));
-        browser.switchTo().frame(iframe);
-        Assert.assertEquals("Inside of the Frame!!", h1.getText().trim());
-    }
+    public class PageFragmentWithGrapheneElementAsRoot {
 
-    @Test
-    public void testInjectedIframe() {
-        browser.switchTo().frame(iframe);
-        Assert.assertEquals("Inside of the Frame!!", h1.getText().trim());
-    }
+        @Root
+        private GrapheneElement root;
 
+        @FindBy(id = "pseudoroot")
+        private GrapheneElement innerElement;
+
+        public GrapheneElement getInnerElement() {
+            return innerElement;
+        }
+
+        public GrapheneElement getRoot() {
+            return root;
+        }
+    }
 }

--- a/impl/src/main/java/org/jboss/arquillian/graphene/GrapheneElementImpl.java
+++ b/impl/src/main/java/org/jboss/arquillian/graphene/GrapheneElementImpl.java
@@ -1,0 +1,254 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.graphene;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.Dimension;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.Point;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.internal.Coordinates;
+import org.openqa.selenium.internal.Locatable;
+
+/**
+ * <p>
+ * Interface for Graphene extensions of {@link WebElement}.
+ * </p>
+ *
+ * <p>
+ * Following methods are provided over the {@link WebElement} interface:
+ * </p>
+ *
+ * <ul>
+ * <li>{@link #isPresent()}</li>
+ * <li>{@link #findGrapheneElements(By)}</li>
+ * </ul>
+ *
+ * <p>
+ * <b>Important</b>: {@link GrapheneElementImpl} <i>is not intended for extension</i>, do not subclass it. The
+ * {@link GrapheneElementImpl} might become abstract class or interface in the future. It can't be final because then it couldn't be
+ * proxied by Graphene.
+ * </p>
+ *
+ * @author <a href="mailto:jpapouse@redhat.com">Jan Papousek</a>
+ */
+public class GrapheneElementImpl implements GrapheneElement {
+
+    private final WebElement element;
+
+    public GrapheneElementImpl(WebElement element) {
+        this.element = element;
+    }
+
+    @Override
+    public boolean isPresent() {
+        try {
+            element.isDisplayed();
+            return true;
+        } catch (NoSuchElementException ignored) {
+            return false;
+        }
+    }
+
+    @Override
+    public List<GrapheneElement> findGrapheneElements(By by) {
+        List<GrapheneElement> grapheneElements = new LinkedList<GrapheneElement>();
+        for (WebElement e : element.findElements(by)) {
+            grapheneElements.add(new GrapheneElementImpl(e));
+        }
+        return grapheneElements;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#click()
+     */
+    @Override
+    public void click() {
+        element.click();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#submit()
+     */
+    @Override
+    public void submit() {
+        element.submit();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#sendKeys(java.lang.CharSequence[])
+     */
+    @Override
+    public void sendKeys(CharSequence... keysToSend) {
+        element.sendKeys(keysToSend);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#clear()
+     */
+    @Override
+    public void clear() {
+        element.clear();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#getTagName()
+     */
+    @Override
+    public String getTagName() {
+        return element.getTagName();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#getAttribute(java.lang.String)
+     */
+    @Override
+    public String getAttribute(String name) {
+        return element.getAttribute(name);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#isSelected()
+     */
+    @Override
+    public boolean isSelected() {
+        return element.isSelected();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#isEnabled()
+     */
+    @Override
+    public boolean isEnabled() {
+        return element.isEnabled();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#getText()
+     */
+    @Override
+    public String getText() {
+        return element.getText();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#findElements(org.openqa.selenium.By)
+     */
+    @Override
+    public List<WebElement> findElements(By by) {
+        return element.findElements(by);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#findElement(org.openqa.selenium.By)
+     */
+    @Override
+    public GrapheneElementImpl findElement(By by) {
+        return new GrapheneElementImpl(element.findElement(by));
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#isDisplayed()
+     */
+    @Override
+    public boolean isDisplayed() {
+        return element.isDisplayed();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#getLocation()
+     */
+    @Override
+    public Point getLocation() {
+        return element.getLocation();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#getSize()
+     */
+    @Override
+    public Dimension getSize() {
+        return element.getSize();
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.WebElement#getCssValue(java.lang.String)
+     */
+    @Override
+    public String getCssValue(String propertyName) {
+        return element.getCssValue(propertyName);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.internal.WrapsElement#getWrappedElement()
+     */
+    @Override
+    public WebElement getWrappedElement() {
+        return element;
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.internal.Locatable#getCoordinates()
+     */
+    @Override
+    public Coordinates getCoordinates() {
+        return ((Locatable) element).getCoordinates();
+    }
+
+}

--- a/impl/src/main/java/org/jboss/arquillian/graphene/enricher/WebElementUtils.java
+++ b/impl/src/main/java/org/jboss/arquillian/graphene/enricher/WebElementUtils.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.jboss.arquillian.graphene.GrapheneElement;
 import org.jboss.arquillian.graphene.context.GrapheneContext;
 import org.jboss.arquillian.graphene.findby.ByJQuery;
 import org.jboss.arquillian.graphene.intercept.InterceptorBuilder;
@@ -55,6 +56,10 @@ public final class WebElementUtils {
     private static final Logger LOGGER = Logger.getLogger(WebElementUtils.class.getName());
     private static final String EMPTY_FIND_BY_WARNING = " Be aware of the fact that fields anotated with empty "
             + "@FindBy were located by default strategy, which is ByIdOrName with field name as locator! ";
+
+    private static final Class<?>[] INTERFACES_PROXY_SHOULD_IMPLEMENET = {Locatable.class,
+        WrapsElement.class, FindsByClassName.class, FindsByCssSelector.class, FindsById.class, FindsByLinkText.class,
+        FindsByName.class, FindsByTagName.class, FindsByXPath.class, GrapheneElement.class};
 
     private WebElementUtils() {
     }
@@ -133,9 +138,7 @@ public final class WebElementUtils {
     }
 
     protected static WebElement findElement(GrapheneContext context, final GrapheneProxy.FutureTarget target) {
-        final WebElement element = GrapheneProxy.getProxyForFutureTarget(context, target, WebElement.class, Locatable.class,
-                WrapsElement.class, FindsByClassName.class, FindsByCssSelector.class, FindsById.class, FindsByLinkText.class,
-                FindsByName.class, FindsByTagName.class, FindsByXPath.class);
+        final WebElement element = GrapheneProxy.getProxyForFutureTarget(context, target, WebElement.class, INTERFACES_PROXY_SHOULD_IMPLEMENET);
         final GrapheneProxyInstance elementProxy = (GrapheneProxyInstance) element;
 
         InterceptorBuilder b = new InterceptorBuilder();


### PR DESCRIPTION
- GrapheneElement can be now used as field type for Page Fragment @Root
- It required couple of refactorins: I had to extract interface from
  GrapheneElement, because proxy which is created for it needs that
  interface in the list of interfaces which it should implement
- I had to rename the implementation to GrapheneElementImpl
- GrapheneElement is wrapped element, I had to add to the
  WrapperEnricher conditional code which would take into account the
  GrapheneElement - it is ugly bit imo only only solution right now
