### PR TITLE
ARQGRA-413: making GrapheneElement working with @InFrame

### DIFF
--- a/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/TestInFrameFunctionalityWithGrapheneElement.java
+++ b/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/TestInFrameFunctionalityWithGrapheneElement.java
@@ -1,0 +1,75 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.graphene.ftest.enricher;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.drone.api.annotation.Drone;
+import org.jboss.arquillian.graphene.ftest.Resource;
+import org.jboss.arquillian.graphene.ftest.Resources;
+import org.jboss.arquillian.graphene.ftest.enricher.page.GrapheneElementWithInFrameAnnotationPage;
+import org.jboss.arquillian.graphene.page.Page;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.openqa.selenium.WebDriver;
+
+/**
+ * @author <a href="mailto:jhuska@redhat.com">Juraj Huska</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class TestInFrameFunctionalityWithGrapheneElement {
+
+    @Drone
+    private WebDriver browser;
+
+    @Page
+    private GrapheneElementWithInFrameAnnotationPage page;
+
+    @ArquillianResource
+    private URL contextRoot;
+
+    private static final String EXPECTED_GRAPHENE_ELEMENT_IN_FRAME_TEXT = "not correct";
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return Resources.inCurrentPackage().all().buildWar("test.war");
+    }
+
+    @Before
+    public void loadPage() {
+        Resource.inCurrentPackage().find("inframe.html").loadPage(browser, contextRoot);
+    }
+
+    @Test
+    public void testGrapheneElementShouldWorkWithInFrameAnnotation() {
+        assertEquals(EXPECTED_GRAPHENE_ELEMENT_IN_FRAME_TEXT, page.getSpan().getText());
+    }
+}

--- a/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/page/GrapheneElementWithInFrameAnnotationPage.java
+++ b/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/page/GrapheneElementWithInFrameAnnotationPage.java
@@ -1,0 +1,37 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.graphene.ftest.enricher.page;
+
+import org.jboss.arquillian.graphene.GrapheneElement;
+import org.jboss.arquillian.graphene.page.InFrame;
+import org.openqa.selenium.support.FindBy;
+
+public class GrapheneElementWithInFrameAnnotationPage {
+
+    @InFrame(index = 0)
+    @FindBy(tagName = "span")
+    private GrapheneElement span;
+
+    public GrapheneElement getSpan() {
+        return span;
+    }
+}

--- a/impl/src/main/java/org/jboss/arquillian/graphene/enricher/InFrameEnricher.java
+++ b/impl/src/main/java/org/jboss/arquillian/graphene/enricher/InFrameEnricher.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.jboss.arquillian.graphene.GrapheneElement;
 import org.jboss.arquillian.graphene.enricher.exception.GrapheneTestEnricherException;
 import org.jboss.arquillian.graphene.page.InFrame;
 import org.jboss.arquillian.graphene.page.Page;
@@ -42,7 +43,7 @@ import org.openqa.selenium.support.ui.Select;
 public class InFrameEnricher extends AbstractSearchContextEnricher {
 
     private final Set<Class<?>> DO_NOT_ENRICH_FURTHER = new HashSet<Class<?>>(Arrays.asList(new Class<?>[] { WebElement.class,
-            Select.class, List.class, WebDriver.class }));
+            Select.class, List.class, WebDriver.class, GrapheneElement.class}));
 
     @Override
     public void enrich(SearchContext searchContext, Object objectToEnrich) {


### PR DESCRIPTION
- GrepheneElement added to the set which contains classes to not enrich
  further, when they are annotated with @InFrame annotation
- I chose this way of determination, because we can not say to the
  future that all interfaces will be ignored, as we are planning to
  enable programming to an interface, not an implementation.
- At the same time we do not want to enrich further some custom
  implementations: e.g. org.openqa.selenium.support.ui.Select
