### PR TITLE
added lifecycle plugin to cover unpack goal for ftest project

### DIFF
--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -149,6 +149,34 @@
                 </executions>
             </plugin>
         </plugins>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-dependency-plugin</artifactId>
+                                        <versionRange>[2.0,)</versionRange>
+                                        <goals>
+                                            <goal>unpack</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <execute />
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <profiles>
@@ -187,7 +215,7 @@
                 <remote>true</remote>
             </properties>
         </profile>
-        
+
         <profile>
             <id>take-screenshots</id>
             <dependencies>
@@ -198,6 +226,6 @@
                 </dependency>
             </dependencies>
         </profile>
-        
+
     </profiles>
 </project>


### PR DESCRIPTION
@jhuska @lfryc

Every time I import whole Graphene project into Eclipse, pom.xml file of ftest module is marked as errorneous since it can not handle unpacking of some bits by eclipse lifecycle.

This is well known issue and it is solved by adding lifecycle plugin into pluginManagement (1)

This issue should be backported to 2.0.x branch as well.

(1) https://stackoverflow.com/questions/8706017/maven-dependency-plugin-goals-copy-dependencies-unpack-is-not-supported-b
