### PR TITLE
ARGQGRA-468 Cannot use relative @Location when using "standalone" JUnit ...

### DIFF
--- a/impl/src/main/java/org/jboss/arquillian/graphene/GrapheneExtension.java
+++ b/impl/src/main/java/org/jboss/arquillian/graphene/GrapheneExtension.java
@@ -39,6 +39,7 @@ import org.jboss.arquillian.graphene.enricher.SeleniumResourceProvider;
 import org.jboss.arquillian.graphene.enricher.WebElementEnricher;
 import org.jboss.arquillian.graphene.enricher.WebElementWrapperEnricher;
 import org.jboss.arquillian.graphene.integration.GrapheneEnhancer;
+import org.jboss.arquillian.graphene.location.ContainerCustomizableURLResourceProvider;
 import org.jboss.arquillian.graphene.location.ContextRootStoreInitializer;
 import org.jboss.arquillian.graphene.location.CustomizableURLResourceProvider;
 import org.jboss.arquillian.graphene.location.LocationEnricher;
@@ -81,9 +82,11 @@ public class GrapheneExtension implements LoadableExtension {
         /* Resource Providers */
         builder.service(ResourceProvider.class, GrapheneContextProvider.class);
         builder.service(ResourceProvider.class, GrapheneConfigurationResourceProvider.class);
-
+        // ARQGRA-468 make usage of Graphen custom URL possible without container test dependency
         if (SecurityActions.isClassPresent("org.jboss.arquillian.container.test.impl.enricher.resource.URLResourceProvider")) {
-            builder.override(ResourceProvider.class, URLResourceProvider.class, CustomizableURLResourceProvider.class);
+            builder.override(ResourceProvider.class, URLResourceProvider.class, ContainerCustomizableURLResourceProvider.class);
+        } else {
+            builder.service(ResourceProvider.class, CustomizableURLResourceProvider.class);
         }
 
         SeleniumResourceProvider.registerAllProviders(builder);

--- a/impl/src/main/java/org/jboss/arquillian/graphene/location/ContainerCustomizableURLResourceProvider.java
+++ b/impl/src/main/java/org/jboss/arquillian/graphene/location/ContainerCustomizableURLResourceProvider.java
@@ -1,0 +1,68 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.graphene.location;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.impl.enricher.resource.URLResourceProvider;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.spi.ServiceLoader;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+import java.lang.annotation.Annotation;
+import java.net.URL;
+
+/**
+ * This resource provider is used if the Arquillian (core) resource provider for URLs is present on the classpath at
+ * extension load time, i.e. you use the container integration option (see see https://docs.jboss.org/author/display/ARQGRA2/Framework+Integration+Options).
+ * It will be used to ask the core resource provider first and only if the URL remains unknown, it
+ * will fallback to the custom URL configured in Graphene configuration.
+ */
+public class ContainerCustomizableURLResourceProvider extends CustomizableURLResourceProvider {
+
+    @Inject
+    private Instance<TestClass> testClass;
+
+    @Inject
+    private Instance<ServiceLoader> loader;
+
+    @Override
+    protected URL doLookup(ArquillianResource resource, Annotation... qualifiers) {
+        URL url = null;
+        // if the class for core (Arquillian) URL resource provider is present, try if a fallback is possible
+        ResourceProvider coreResourceProvider = loader.get().onlyOne(ResourceProvider.class, URLResourceProvider.class);
+        if (coreResourceProvider != null && coreResourceProvider instanceof URLResourceProvider) {
+            if (hasDeployment(testClass.get())) {
+                url = (URL) coreResourceProvider.lookup(resource, qualifiers);
+            } else {
+                url = (URL) ((URLResourceProvider) coreResourceProvider).doLookup(resource, qualifiers);
+            }
+        }
+        return url;
+    }
+
+    private boolean hasDeployment(TestClass testClass) {
+        return testClass.getMethods(Deployment.class).length != 0;
+    }
+}

--- a/impl/src/main/java/org/jboss/arquillian/graphene/location/CustomizableURLResourceProvider.java
+++ b/impl/src/main/java/org/jboss/arquillian/graphene/location/CustomizableURLResourceProvider.java
@@ -21,41 +21,39 @@
  */
 package org.jboss.arquillian.graphene.location;
 
-import java.lang.annotation.Annotation;
-import java.net.MalformedURLException;
-import java.net.URL;
-
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.impl.enricher.resource.URLResourceProvider;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.graphene.spi.configuration.GrapheneConfiguration;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
-public class CustomizableURLResourceProvider extends URLResourceProvider {
+import java.lang.annotation.Annotation;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * The CustomizableURLResourceProvider is used in the context of Graphene, if you use
+ * the standalone framework integration option (see https://docs.jboss.org/author/display/ARQGRA2/Framework+Integration+Options)
+ * and thus the Arquillian {@link org.jboss.arquillian.container.test.impl.enricher.resource.URLResourceProvider} is not on
+ * on the classpath.
+ *
+ * @see org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider
+ * @see ContainerCustomizableURLResourceProvider
+ */
+public class CustomizableURLResourceProvider implements ResourceProvider {
 
     @Inject
     private Instance<GrapheneConfiguration> grapheneConfiguration;
 
-    @Inject
-    private Instance<TestClass> testClass;
-
     @Override
     public boolean canProvide(Class<?> type) {
-        return super.canProvide(type);
+        return URL.class.isAssignableFrom(type);
     }
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
 
-        URL url = null;
-
-        if (hasDeployment(testClass.get())) {
-            url = (URL) super.lookup(resource, qualifiers);
-        } else {
-            url = (URL) super.doLookup(resource, qualifiers);
-        }
+        URL url = doLookup(resource, qualifiers);
 
         if (url == null) {
 
@@ -74,7 +72,7 @@ public class CustomizableURLResourceProvider extends URLResourceProvider {
         return url;
     }
 
-    private boolean hasDeployment(TestClass testClass) {
-        return testClass.getMethods(Deployment.class).length != 0;
+    protected URL doLookup(ArquillianResource resource, Annotation... qualifiers) {
+        return null;
     }
 }


### PR DESCRIPTION
...integration

Changed GrapheneExtension to setup ResourceProvider for URL depending on the framework integration options.
If container framework integration option is used, then ContainerCustomizableURLResourceProvider is chosen, which first delegates to URLResourceProvider of Arquillian.
If stand-alone framework inegration option is used, then CustomizableURLResourceProvider is chosen, which returns the Graphene custom URL if present.