### PR TITLE
screenshooter tests: updated tomcat version to 7.0.55

### DIFF
--- a/extension/screenshooter/pom.xml
+++ b/extension/screenshooter/pom.xml
@@ -9,7 +9,8 @@
     License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
     OF ANY KIND, either express or implied. See the License for the specific
     language governing permissions and limitations under the License. -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -27,7 +28,7 @@
     <properties>
         <version.recorder.screenshooter>1.0.0.Beta1</version.recorder.screenshooter>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        
+
         <browser>phantomjs</browser>
         <remote>false</remote>
         <remoteReusable>false</remoteReusable>
@@ -35,10 +36,10 @@
 
         <platform>ANY</platform>
         <browser.version>undefined</browser.version>
-        
-        <tomcat.version>7.0.26</tomcat.version>
+
+        <tomcat.version>7.0.55</tomcat.version>
         <tomcat.home>target/apache-tomcat-${tomcat.version}</tomcat.home>
-        <arquillian.tomcat.version>1.0.0.CR4</arquillian.tomcat.version>
+        <arquillian.tomcat.version>1.0.0.CR6</arquillian.tomcat.version>
     </properties>
 
     <dependencies>
@@ -76,7 +77,7 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-tomcat-managed-7</artifactId>
@@ -84,7 +85,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
     <build>
         <testResources>
             <testResource>
@@ -117,13 +118,14 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>com.googlecode.t7mp</groupId>
+                                    <groupId>org.apache.tomcat</groupId>
                                     <artifactId>tomcat</artifactId>
-                                    <version>${tomcat.version}.A</version>
+                                    <version>${tomcat.version}</version>
                                     <type>zip</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
                                 </artifactItem>
+
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -152,7 +154,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>webdriver-chrome</id>

--- a/extension/screenshooter/src/test/resources/arquillian.xml
+++ b/extension/screenshooter/src/test/resources/arquillian.xml
@@ -64,7 +64,7 @@
             </property>
             <property name="user">tomcat</property>
             <property name="pass">tomcat</property>
-            <property name="catalinaHome">target/apache-tomcat-7.0.26</property>
+            <property name="catalinaHome">target/apache-tomcat-7.0.55</property>
         </configuration>
     </container>
 </arquillian>


### PR DESCRIPTION
the screenshooter tests had been failing on java 8 because of the old tomcat