### PR TITLE
updated to Drone 2.0.0.Alpha5 with Selenium 2.47.1

### DIFF
--- a/extension/screenshooter/pom.xml
+++ b/extension/screenshooter/pom.xml
@@ -40,6 +40,8 @@
         <tomcat.version>7.0.55</tomcat.version>
         <tomcat.home>target/apache-tomcat-${tomcat.version}</tomcat.home>
         <arquillian.tomcat.version>1.0.0.CR6</arquillian.tomcat.version>
+
+        <version.fest-assert>1.4</version.fest-assert>
     </properties>
 
     <dependencies>
@@ -63,7 +65,7 @@
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-drone-webdriver</artifactId>
         </dependency>
-        
+
         <!-- Arquillian JUnit -->
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
@@ -75,6 +77,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.easytesting</groupId>
+            <artifactId>fest-assert</artifactId>
+            <version>${version.fest-assert}</version>
             <scope>test</scope>
         </dependency>
 

--- a/impl/src/main/java/org/jboss/arquillian/graphene/GrapheneElementImpl.java
+++ b/impl/src/main/java/org/jboss/arquillian/graphene/GrapheneElementImpl.java
@@ -27,7 +27,9 @@ import java.util.List;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.OutputType;
 import org.openqa.selenium.Point;
+import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.internal.Coordinates;
 import org.openqa.selenium.internal.Locatable;
@@ -251,4 +253,12 @@ public class GrapheneElementImpl implements GrapheneElement {
         return ((Locatable) element).getCoordinates();
     }
 
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.openqa.selenium.TakesScreenshot#getScreenshotAs(org.openqa.selenium.OutputType)
+     */
+    @Override public <X> X getScreenshotAs(OutputType<X> outputType) throws WebDriverException {
+        return element.getScreenshotAs(outputType);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <maven.compiler.argument.source>1.5</maven.compiler.argument.source>
 
         <!-- Arquillian -->
-        <version.arquillian.core>1.1.5.Final</version.arquillian.core>
+        <version.arquillian.core>1.1.8.Final</version.arquillian.core>
         <version.arquillian.drone>2.0.0.Alpha3</version.arquillian.drone>
 
         <!-- Runtime dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
         <!-- Arquillian -->
         <version.arquillian.core>1.1.8.Final</version.arquillian.core>
-        <version.arquillian.drone>2.0.0.Alpha3</version.arquillian.drone>
+        <version.arquillian.drone>2.0.0.Alpha5</version.arquillian.drone>
 
         <!-- Runtime dependencies -->
         <version.cglib>2.2.2</version.cglib>


### PR DESCRIPTION
https://issues.jboss.org/browse/ARQGRA-477

There in the new Selenium 2.47.1, the interface WebElement newly extends an interface TakesScreenshot - see the commit https://github.com/SeleniumHQ/selenium/commit/476917ba5a57c1f93b71211fded9558ad2c9909d 
This causes that the class GrapheneElementImpl has to have implement another method from the interface TakesScreenshot - fix is included in this PR