### PR TITLE
Add support for multiple @InitialPage with parallel browsers

### DIFF
--- a/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/TestPageObjectsLocation.java
+++ b/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/TestPageObjectsLocation.java
@@ -42,6 +42,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
+import qualifier.Browser2;
 import qualifier.Browser3;
 
 @RunWith(Arquillian.class)
@@ -50,6 +51,10 @@ public class TestPageObjectsLocation {
 
     @Drone
     private WebDriver browser;
+
+    @Drone
+    @Browser2
+    private WebDriver browser2;
 
     @Drone
     @Browser3
@@ -109,6 +114,21 @@ public class TestPageObjectsLocation {
     public void testInitialPageCustomBrowser(@Browser3 @InitialPage MyPageObject2 obj) {
         browser.get(contextRoot.toExternalForm());
         checkMyPageObject2(obj);
+    }
+
+    @Test
+    public void testMultipleInitialPagesWithCustomBrowsers(
+        @Browser2 @InitialPage MyPageObject2 page1,
+        @Browser3 @InitialPage MyPageObject2 page2) {
+        browser.get(contextRoot.toExternalForm());
+        checkMyPageObject2(page1);
+        checkMyPageObject2(page2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMultipleInitialPagesGoingToSameBrowser(
+        @Browser2 @InitialPage MyPageObject2 page1,
+        @Browser2 @InitialPage MyPageObject2 page2) {
     }
 
     @Test


### PR DESCRIPTION
Fixes ARQGRA-478

--
Codebase gets all parameter indices that contain the @InitialPage and works through each one.  If it finds that multiple @InitialPage parameters have the same Qualifier, it throws.

Ran the full test suite afterwards and it all passed.