### PR TITLE
Propagate xhr.response values in callback

### DIFF
--- a/impl/src/main/javascript/Graphene.xhrInterception.js
+++ b/impl/src/main/javascript/Graphene.xhrInterception.js
@@ -129,6 +129,7 @@ window.Graphene.xhrInterception = (function() {
             //do not use 'this' since host objects behave differently
             wrapper.readyState = wrapper.xhr.readyState;
             if (wrapper.readyState == 4) {
+                wrapper.response = wrapper.xhr.response;
                 wrapper.responseText = wrapper.xhr.responseText;
                 wrapper.responseXML = wrapper.xhr.responseXML;
                 wrapper.status = wrapper.xhr.status;


### PR DESCRIPTION
When the xhr wrapper is created the response property is copied but it isn't updated in the callback, which leads to the property values' being out of sync. Some frameworks (e.g. Angular) will use the xhr.response over xhr.responseText if it is present, which means that simply using a guardAjax in a Graphene test will cause all subsequent xhr calls to return invalid data. In my case (Firefox 38, Angular 1.4.4, Graphene 2.0.3.Final) all $http calls would return "" once a guardAjax was executed, despite valid data being shown in Firefox's request log.