### PR TITLE
Fix window.setTimeout result not being returned

### DIFF
--- a/impl/src/main/javascript/Graphene.Page.RequestGuard.js
+++ b/impl/src/main/javascript/Graphene.Page.RequestGuard.js
@@ -35,7 +35,7 @@ window.Graphene.Page.RequestGuard = (function() {
         window.setTimeout = function(originalCallback, timeout) {
             if (timeout > window.Graphene.Page.RequestGuard.maximumCallbackTimeout) {
                  //provide 'apply' borrowed from Function for the case the host object does not have the own
-                 Function.prototype.apply.call(xhr.originalTimeout, window, arguments);
+                 return Function.prototype.apply.call(xhr.originalTimeout, window, arguments);
             } else {
                 xhr.callbackCount += 1;
                 
@@ -46,7 +46,7 @@ window.Graphene.Page.RequestGuard = (function() {
                     }
                 }
                 //provide 'call' borrowed from Function for the case the host object does not have the own
-                Function.prototype.call.call(xhr.originalTimeout, window, function() {
+                return Function.prototype.call.call(xhr.originalTimeout, window, function() {
                     try {
                         replaceTimeout(xhr);
                         if (typeof(originalCallback) === 'string') {


### PR DESCRIPTION
When replacing window.setTimeout with its own interceptor version, Graphene did not return the timeout handle that is needed to clear the timeout later.

I saw there are some requirements for contributing, but that seems a lot to go through for a change of 14 characters. I hope it's possible to incorporate these changes without creating issues in the issue tracker,   signing agreements etc.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-graphene/159)

<!-- Reviewable:end -->
