### PR TITLE
Sets URL scheme precedence over scheme property.

### DIFF
--- a/spi/src/main/java/org/jboss/arquillian/graphene/spi/configuration/GrapheneConfiguration.java
+++ b/spi/src/main/java/org/jboss/arquillian/graphene/spi/configuration/GrapheneConfiguration.java
@@ -203,7 +203,10 @@ public class GrapheneConfiguration implements DroneConfiguration<GrapheneConfigu
         boolean canConstruct;
 
         try {
-            new URL(url);
+            final URL currentUrl = new URL(url);
+            if (currentUrl.getProtocol() != null) {
+                this.scheme = currentUrl.getProtocol();
+            }
             canConstruct = true;
         } catch (MalformedURLException ex) {
             canConstruct = false;


### PR DESCRIPTION

#### Short description of what this resolves:
Graphene allows you to configure two properties, scheme and url. The problem is that Scheme might be http, https, ... and the URL instead of being the host + port + context definition, it is a full URL. SO it means that you could configure URL using https and scheme using http and then internally both values might be used independently.

#### Changes proposed in this pull request:

- The ideal scenario would be that URL protocol takes precedence over scheme
-
-


**Fixes**: https://issues.jboss.org/browse/ARQGRA-495
