### PR TITLE
ARQGRA-505 Implemented additional API methods for Action operations directly into Graphene class

### DIFF
--- a/api/src/main/java/org/jboss/arquillian/graphene/Graphene.java
+++ b/api/src/main/java/org/jboss/arquillian/graphene/Graphene.java
@@ -322,4 +322,36 @@ public class Graphene {
     private static GrapheneRuntime instance() {
         return GrapheneRuntime.getInstance();
     }
+
+    /**
+     * Clicks in the middle of the given element. Equivalent to:
+     * <i>Actions.moveToElement(onElement).click().perform()</i>
+     *
+     * @param element Element to click.
+     */
+    public static void click(WebElement element){
+        instance().click(element);
+    }
+
+    /**
+     * Performs a double-click at middle of the given element. Equivalent to:
+     * <i>Actions.moveToElement(element).doubleClick().perform()</i>
+     *
+     * @param element Element to move to.
+     */
+    public static void doubleClick(WebElement element) {
+        instance().doubleClick(element);
+    }
+
+    /**
+     * Writes into the given element the given string. Equivalent to:
+     * <i>Actions.moveToElement(element).click().sendKeys(text).perform()</i>
+     *
+     * @param element Element to move to.
+     * @param text Text to write
+     */
+    public static void writeIntoElement(WebElement element, String text) {
+       instance().writeIntoElement(element, text);
+    }
+
 }

--- a/api/src/main/java/org/jboss/arquillian/graphene/GrapheneElement.java
+++ b/api/src/main/java/org/jboss/arquillian/graphene/GrapheneElement.java
@@ -54,7 +54,7 @@ import org.openqa.selenium.internal.WrapsElement;
  * @author <a href="mailto:jpapouse@redhat.com">Jan Papousek</a>
  */
 @ImplementedBy(className = "org.jboss.arquillian.graphene.GrapheneElementImpl")
-public interface GrapheneElement extends WebElement, Locatable, WrapsElement {
+public interface GrapheneElement extends WebElement, Locatable, WrapsElement, GrapheneElementAction {
 
     /**
      * <p>

--- a/api/src/main/java/org/jboss/arquillian/graphene/GrapheneElementAction.java
+++ b/api/src/main/java/org/jboss/arquillian/graphene/GrapheneElementAction.java
@@ -1,0 +1,44 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.graphene;
+
+import org.openqa.selenium.WebElement;
+
+/**
+ * An interface containing actions to be operated on an {@link WebElement}
+ */
+public interface GrapheneElementAction {
+
+    /**
+     * Performs a double-click at middle of an element. Equivalent to:
+     * <i>Actions.moveToElement(element).doubleClick().perform()</i>
+     */
+    void doubleClick();
+
+    /**
+     * Writes into an element the given string. Equivalent to:
+     * <i>Actions.moveToElement(element).click().sendKeys(text).perform()</i>
+     *
+     * @param text Text to write
+     */
+    void writeIntoElement(String text);
+}

--- a/api/src/main/java/org/jboss/arquillian/graphene/GrapheneRuntime.java
+++ b/api/src/main/java/org/jboss/arquillian/graphene/GrapheneRuntime.java
@@ -136,4 +136,19 @@ public abstract class GrapheneRuntime {
         }
         return RUNTIMES_STACK.get().pop();
     }
+
+    /**
+     * @see Graphene#doubleClick(WebElement)
+     */
+    public abstract void doubleClick(WebElement element);
+
+    /**
+     * @see Graphene#click(WebElement)
+     */
+    public abstract void click(WebElement element);
+
+    /**
+     * @see Graphene#writeIntoElement(WebElement)
+     */
+    protected abstract void writeIntoElement(WebElement element, String text);
 }

--- a/impl/src/main/java/org/jboss/arquillian/graphene/DefaultGrapheneRuntime.java
+++ b/impl/src/main/java/org/jboss/arquillian/graphene/DefaultGrapheneRuntime.java
@@ -39,6 +39,7 @@ import org.jboss.arquillian.graphene.wait.WebDriverWait;
 import org.jboss.arquillian.graphene.wait.WebDriverWaitImpl;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 
 public class DefaultGrapheneRuntime extends GrapheneRuntime {
 
@@ -123,6 +124,21 @@ public class DefaultGrapheneRuntime extends GrapheneRuntime {
     public <T> T goTo(Class<T> pageObject, Class<?> browserQualifier) {
         LocationEnricher locationEnricher = serviceLoader.get().onlyOne(LocationEnricher.class);
         return locationEnricher.goTo(pageObject, browserQualifier);
+    }
+
+    @Override
+    public void doubleClick(WebElement element) {
+        new Actions(context().getWebDriver()).doubleClick(element).perform();
+    }
+
+    @Override
+    public void click(WebElement element) {
+        new Actions(context().getWebDriver()).click(element).perform();
+    }
+
+    @Override
+    protected void writeIntoElement(WebElement element, String text) {
+        new Actions(context().getWebDriver()).moveToElement(element).click().sendKeys(text).perform();
     }
 
     private RequestGuardFactory getRequestGuardFactoryFor(Object target) {

--- a/impl/src/main/java/org/jboss/arquillian/graphene/GrapheneElementImpl.java
+++ b/impl/src/main/java/org/jboss/arquillian/graphene/GrapheneElementImpl.java
@@ -302,4 +302,14 @@ public class GrapheneElementImpl implements GrapheneElement {
     public String toString() {
         return "GrapheneElement -> " + element;
     }
+
+    @Override
+    public void doubleClick() {
+        Graphene.doubleClick(element);
+    }
+
+    @Override
+    public void writeIntoElement(String text) {
+        Graphene.writeIntoElement(element, text);
+    }
 }

--- a/impl/src/test/java/org/jboss/arquillian/graphene/GrapheneActionOperationsBootstrap.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/GrapheneActionOperationsBootstrap.java
@@ -38,7 +38,7 @@ import org.openqa.selenium.interactions.Mouse;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public abstract class TestAbstractGrapheneActionOperations {
+public abstract class GrapheneActionOperationsBootstrap {
 
     @Mock(extraInterfaces = HasInputDevices.class)
     HtmlUnitDriver driver;

--- a/impl/src/test/java/org/jboss/arquillian/graphene/GrapheneActionOperationsBootstrap.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/GrapheneActionOperationsBootstrap.java
@@ -26,34 +26,30 @@ import org.jboss.arquillian.graphene.context.GrapheneContext;
 import org.jboss.arquillian.graphene.spi.configuration.GrapheneConfiguration;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.htmlunit.HtmlUnitWebElement;
 import org.openqa.selenium.interactions.HasInputDevices;
 import org.openqa.selenium.interactions.Keyboard;
 import org.openqa.selenium.interactions.Mouse;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
-@RunWith(MockitoJUnitRunner.class)
 public abstract class GrapheneActionOperationsBootstrap {
 
-    @Mock(extraInterfaces = HasInputDevices.class)
     HtmlUnitDriver driver;
-
-    @Mock
     Mouse mouse;
-
-    @Mock
     Keyboard keyboard;
-
-    @Mock
     HtmlUnitWebElement webElement;
 
     @Before
     public final void setUp() {
+        driver = mock(HtmlUnitDriver.class, withSettings().extraInterfaces(HasInputDevices.class));
+        mouse = mock(Mouse.class);
+        keyboard = mock(Keyboard.class);
+        webElement = mock(HtmlUnitWebElement.class);
+
         GrapheneContext.setContextFor(new GrapheneConfiguration(), driver, Default.class);
         GrapheneRuntime.pushInstance(new DefaultGrapheneRuntime());
 

--- a/impl/src/test/java/org/jboss/arquillian/graphene/TestAbstractGrapheneActionOperations.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/TestAbstractGrapheneActionOperations.java
@@ -1,0 +1,69 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.graphene;
+
+import org.jboss.arquillian.drone.api.annotation.Default;
+import org.jboss.arquillian.graphene.context.GrapheneContext;
+import org.jboss.arquillian.graphene.spi.configuration.GrapheneConfiguration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
+import org.openqa.selenium.htmlunit.HtmlUnitWebElement;
+import org.openqa.selenium.interactions.HasInputDevices;
+import org.openqa.selenium.interactions.Keyboard;
+import org.openqa.selenium.interactions.Mouse;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public abstract class TestAbstractGrapheneActionOperations {
+
+    @Mock(extraInterfaces = HasInputDevices.class)
+    HtmlUnitDriver driver;
+
+    @Mock
+    Mouse mouse;
+
+    @Mock
+    Keyboard keyboard;
+
+    @Mock
+    HtmlUnitWebElement webElement;
+
+    @Before
+    public final void setUp() {
+        GrapheneContext.setContextFor(new GrapheneConfiguration(), driver, Default.class);
+        GrapheneRuntime.pushInstance(new DefaultGrapheneRuntime());
+
+        when(((HasInputDevices) driver).getMouse()).thenReturn(mouse);
+        when(((HasInputDevices) driver).getKeyboard()).thenReturn(keyboard);
+    }
+
+    @After
+    public void tearDown() {
+        GrapheneRuntime.popInstance();
+        GrapheneContext.removeContextFor(Default.class);
+    }
+}

--- a/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneActionOperations.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneActionOperations.java
@@ -22,14 +22,11 @@
 package org.jboss.arquillian.graphene;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.openqa.selenium.internal.Locatable;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-@RunWith(MockitoJUnitRunner.class)
 public class TestGrapheneActionOperations extends GrapheneActionOperationsBootstrap {
 
     @Test

--- a/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneActionOperations.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneActionOperations.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @RunWith(MockitoJUnitRunner.class)
-public class TestGrapheneActionOperations extends TestAbstractGrapheneActionOperations {
+public class TestGrapheneActionOperations extends GrapheneActionOperationsBootstrap {
 
     @Test
     public void testGrapheneActionClick() {

--- a/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneActionOperations.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneActionOperations.java
@@ -1,0 +1,105 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc. and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.arquillian.graphene;
+
+import org.jboss.arquillian.drone.api.annotation.Default;
+import org.jboss.arquillian.graphene.context.GrapheneContext;
+import org.jboss.arquillian.graphene.spi.configuration.GrapheneConfiguration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.openqa.selenium.htmlunit.HtmlUnitDriver;
+import org.openqa.selenium.htmlunit.HtmlUnitWebElement;
+import org.openqa.selenium.interactions.HasInputDevices;
+import org.openqa.selenium.interactions.Keyboard;
+import org.openqa.selenium.interactions.Mouse;
+import org.openqa.selenium.internal.Locatable;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestGrapheneActionOperations {
+
+    @Mock(extraInterfaces = HasInputDevices.class)
+    private HtmlUnitDriver driver;
+
+    @Mock
+    private Mouse mouse;
+
+    @Mock
+    private Keyboard keyboard;
+
+    @Mock
+    private HtmlUnitWebElement webElement;
+
+    @Before
+    public void setUp() {
+        GrapheneContext.setContextFor(new GrapheneConfiguration(), driver, Default.class);
+        GrapheneRuntime.pushInstance(new DefaultGrapheneRuntime());
+
+        when(((HasInputDevices) driver).getMouse()).thenReturn(mouse);
+        when(((HasInputDevices) driver).getKeyboard()).thenReturn(keyboard);
+    }
+
+    @After
+    public void tearDown() {
+        GrapheneRuntime.popInstance();
+        GrapheneContext.removeContextFor(Default.class);
+    }
+
+    @Test
+    public void testGrapheneActionClick() {
+        // when
+        Graphene.click(webElement);
+
+        // then
+        verify(mouse).click(((Locatable) webElement).getCoordinates());
+        verifyNoMoreInteractions(mouse, keyboard);
+    }
+
+    @Test
+    public void testGrapheneActionDoubleClick() {
+        // when
+        Graphene.doubleClick(webElement);
+
+        // then
+        verify(mouse).doubleClick(((Locatable) webElement).getCoordinates());
+        verifyNoMoreInteractions(mouse, keyboard);
+    }
+
+    @Test
+    public void testGrapheneActionWriteIntoElement() {
+        // when
+        Graphene.writeIntoElement(webElement, "hi");
+
+        // then
+        verify(mouse).mouseMove(((Locatable) webElement).getCoordinates());
+        verify(mouse).click(((Locatable) webElement).getCoordinates());
+        verify(keyboard).sendKeys("hi");
+        verifyNoMoreInteractions(mouse, keyboard);
+    }
+}

--- a/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneElementActionOperations.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneElementActionOperations.java
@@ -23,14 +23,11 @@ package org.jboss.arquillian.graphene;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 import org.openqa.selenium.internal.Locatable;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-@RunWith(MockitoJUnitRunner.class)
 public class TestGrapheneElementActionOperations extends GrapheneActionOperationsBootstrap {
 
     private GrapheneElement grapheneElement;

--- a/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneElementActionOperations.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneElementActionOperations.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.arquillian.graphene;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -30,36 +31,33 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @RunWith(MockitoJUnitRunner.class)
-public class TestGrapheneActionOperations extends TestAbstractGrapheneActionOperations {
+public class TestGrapheneElementActionOperations extends TestAbstractGrapheneActionOperations{
+
+    private GrapheneElement grapheneElement;
+
+    @Before
+    public void createGrapheneElement() {
+        grapheneElement = new GrapheneElementImpl(webElement);
+    }
 
     @Test
-    public void testGrapheneActionClick() {
+    public void testGrapheneElementActionDoubleClick() {
         // when
-        Graphene.click(webElement);
+        grapheneElement.doubleClick();
 
         // then
-        verify(mouse).click(((Locatable) webElement).getCoordinates());
+        verify(mouse).doubleClick(((Locatable) grapheneElement).getCoordinates());
         verifyNoMoreInteractions(mouse, keyboard);
     }
 
     @Test
-    public void testGrapheneActionDoubleClick() {
+    public void testGrapheneElementActionWriteIntoElement() {
         // when
-        Graphene.doubleClick(webElement);
+        grapheneElement.writeIntoElement("hi");
 
         // then
-        verify(mouse).doubleClick(((Locatable) webElement).getCoordinates());
-        verifyNoMoreInteractions(mouse, keyboard);
-    }
-
-    @Test
-    public void testGrapheneActionWriteIntoElement() {
-        // when
-        Graphene.writeIntoElement(webElement, "hi");
-
-        // then
-        verify(mouse).mouseMove(((Locatable) webElement).getCoordinates());
-        verify(mouse).click(((Locatable) webElement).getCoordinates());
+        verify(mouse).mouseMove(((Locatable) grapheneElement).getCoordinates());
+        verify(mouse).click(((Locatable) grapheneElement).getCoordinates());
         verify(keyboard).sendKeys("hi");
         verifyNoMoreInteractions(mouse, keyboard);
     }

--- a/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneElementActionOperations.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneElementActionOperations.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @RunWith(MockitoJUnitRunner.class)
-public class TestGrapheneElementActionOperations extends TestAbstractGrapheneActionOperations{
+public class TestGrapheneElementActionOperations extends GrapheneActionOperationsBootstrap {
 
     private GrapheneElement grapheneElement;
 


### PR DESCRIPTION
Methods:
- click()
- doubleClick()
- writeIntoElement()

Now it should be possible just write:
~~~java
Graphene.writeIntoElement(element, "my text");
Graphene.doubleClick(element);
Graphene.click(element);
~~~
I know that there is a method `click()` directly on WebElement object, but I put it there for completion - not to confuse when there is the `doubleClick()` operation.
