### PR TITLE
updated cglib version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <version.arquillian.drone>2.1.1</version.arquillian.drone>
 
         <!-- Runtime dependencies -->
-        <version.cglib>2.2.2</version.cglib>
+        <version.cglib>3.2.5</version.cglib>
         <version.objenesis>1.2</version.objenesis>
 
         <!-- Tests -->


### PR DESCRIPTION
This library has conflicts if cube is running on `fabric8-docker-client` as fabric8 docker client is using  cglib version 3.2.5 in which has some interface from 2.2.2 changes in abstract class in 3.2.5