### PR TITLE
feat: introduces new withTimeout and pollingEvery alternatives

### DIFF
--- a/api/src/main/java/org/jboss/arquillian/graphene/wait/FluentWait.java
+++ b/api/src/main/java/org/jboss/arquillian/graphene/wait/FluentWait.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.arquillian.graphene.wait;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
@@ -47,6 +48,11 @@ public interface FluentWait<ARG, FLUENT> extends Wait<ARG>, FluentBase<FLUENT> {
     FluentWait<ARG, FLUENT> withMessage(String message);
 
     /**
+     *
+     * This method will be removed in future releases.
+     * With Selenium 4 there is no more need for using value and units separately.
+     * Use {@link FluentWait#withTimeout(duration)} instead.
+     *
      * Sets how long to wait for the evaluated condition to be true. The default
      * timeout is 500ms.
      *
@@ -54,9 +60,17 @@ public interface FluentWait<ARG, FLUENT> extends Wait<ARG>, FluentBase<FLUENT> {
      * @param unit The unit of time.
      * @return A self reference.
      */
+    @Deprecated
     FluentWait<ARG, FLUENT> withTimeout(long duration, TimeUnit unit);
 
+    FluentWait<ARG, FLUENT> withTimeout(Duration duration);
+
     /**
+     *
+     * This method will be removed in future releases.
+     * With Selenium 4 there is no more need for using value and units separately.
+     * Use {@link FluentWait#pollingEvery(duration)} instead.
+     *
      * Sets how often the condition should be evaluated.
      *
      * <p> In reality, the interval may be greater as the cost of actually
@@ -67,7 +81,10 @@ public interface FluentWait<ARG, FLUENT> extends Wait<ARG>, FluentBase<FLUENT> {
      * @param unit The unit of time.
      * @return A self reference.
      */
+    @Deprecated
     FluentWait<ARG, FLUENT> pollingEvery(long duration, TimeUnit unit);
+
+    FluentWait<ARG, FLUENT> pollingEvery(Duration duration);
 
     /**
      * Configures this instance to ignore specific types of exceptions while

--- a/api/src/main/java/org/jboss/arquillian/graphene/wait/FluentWait.java
+++ b/api/src/main/java/org/jboss/arquillian/graphene/wait/FluentWait.java
@@ -48,11 +48,6 @@ public interface FluentWait<ARG, FLUENT> extends Wait<ARG>, FluentBase<FLUENT> {
     FluentWait<ARG, FLUENT> withMessage(String message);
 
     /**
-     *
-     * This method will be removed in future releases.
-     * With Selenium 4 there is no more need for using value and units separately.
-     * Use {@link FluentWait#withTimeout(duration)} instead.
-     *
      * Sets how long to wait for the evaluated condition to be true. The default
      * timeout is 500ms.
      *
@@ -60,17 +55,17 @@ public interface FluentWait<ARG, FLUENT> extends Wait<ARG>, FluentBase<FLUENT> {
      * @param unit The unit of time.
      * @return A self reference.
      */
-    @Deprecated
     FluentWait<ARG, FLUENT> withTimeout(long duration, TimeUnit unit);
 
+    /**
+     * Sets how long to wait for the evaluated condition to be true. The default
+     * timeout is 500ms.
+     *
+     * It is an alternative for {@link #withTimeout(long, TimeUnit)}
+     */
     FluentWait<ARG, FLUENT> withTimeout(Duration duration);
 
     /**
-     *
-     * This method will be removed in future releases.
-     * With Selenium 4 there is no more need for using value and units separately.
-     * Use {@link FluentWait#pollingEvery(duration)} instead.
-     *
      * Sets how often the condition should be evaluated.
      *
      * <p> In reality, the interval may be greater as the cost of actually
@@ -81,9 +76,13 @@ public interface FluentWait<ARG, FLUENT> extends Wait<ARG>, FluentBase<FLUENT> {
      * @param unit The unit of time.
      * @return A self reference.
      */
-    @Deprecated
     FluentWait<ARG, FLUENT> pollingEvery(long duration, TimeUnit unit);
 
+    /**
+     * Sets how often the condition should be evaluated.
+     *
+     * It is an alternative for {@link #pollingEvery(long, TimeUnit)}
+     */
     FluentWait<ARG, FLUENT> pollingEvery(Duration duration);
 
     /**

--- a/api/src/main/java/org/jboss/arquillian/graphene/wait/WebDriverWait.java
+++ b/api/src/main/java/org/jboss/arquillian/graphene/wait/WebDriverWait.java
@@ -35,24 +35,10 @@ public interface WebDriverWait<FLUENT> extends FluentWait<WebDriver, FLUENT> {
 
     FluentWait<WebDriver, FLUENT> withMessage(String message);
 
-    /**
-     * This method will be removed in future releases.
-     * With Selenium 4 there is no more need for using value and units separately.
-     * Use {@link WebDriverWait#withTimeout(duration)} instead.
-     *
-     */
-    @Deprecated
     FluentWait<WebDriver, FLUENT> withTimeout(long duration, TimeUnit unit);
 
     FluentWait<WebDriver, FLUENT> withTimeout(Duration duration);
 
-    /**
-     * This method will be removed in future releases.
-     * With Selenium 4 there is no more need for using value and units separately.
-     * Use {@link WebDriverWait#pollingEvery(duration)} instead.
-     *
-     */
-    @Deprecated
     FluentWait<WebDriver, FLUENT> pollingEvery(long duration, TimeUnit unit);
 
     FluentWait<WebDriver, FLUENT> pollingEvery(Duration duration);

--- a/api/src/main/java/org/jboss/arquillian/graphene/wait/WebDriverWait.java
+++ b/api/src/main/java/org/jboss/arquillian/graphene/wait/WebDriverWait.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.arquillian.graphene.wait;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -34,9 +35,27 @@ public interface WebDriverWait<FLUENT> extends FluentWait<WebDriver, FLUENT> {
 
     FluentWait<WebDriver, FLUENT> withMessage(String message);
 
+    /**
+     * This method will be removed in future releases.
+     * With Selenium 4 there is no more need for using value and units separately.
+     * Use {@link WebDriverWait#withTimeout(duration)} instead.
+     *
+     */
+    @Deprecated
     FluentWait<WebDriver, FLUENT> withTimeout(long duration, TimeUnit unit);
 
+    FluentWait<WebDriver, FLUENT> withTimeout(Duration duration);
+
+    /**
+     * This method will be removed in future releases.
+     * With Selenium 4 there is no more need for using value and units separately.
+     * Use {@link WebDriverWait#pollingEvery(duration)} instead.
+     *
+     */
+    @Deprecated
     FluentWait<WebDriver, FLUENT> pollingEvery(long duration, TimeUnit unit);
+
+    FluentWait<WebDriver, FLUENT> pollingEvery(Duration duration);
 
     <K extends Throwable> FluentWait<WebDriver, FLUENT> ignoreAll(Collection<Class<? extends K>> types);
 

--- a/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/wait/WebDriverWaitTest.java
+++ b/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/wait/WebDriverWaitTest.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.arquillian.graphene.ftest.wait;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import junit.framework.Assert;
@@ -100,6 +101,27 @@ public class WebDriverWaitTest extends AbstractWaitTest {
                     was < unit.toMillis(duration + duration / 2));
             Assert.assertTrue("The waiting time shouldn't lower than " + duration + " " + unit + ", but was " + was + " ms.",
                     was >= unit.toMillis(duration));
+        }
+    }
+
+    @Test
+    public void testWithTimeoutDuration() {
+        Duration duration = Duration.ofMillis(2000);
+        long started = System.currentTimeMillis();
+        try {
+            Graphene.waitModel()
+                    .withTimeout(duration)
+                    .until()
+                    .element(BY_HEADER)
+                    .text()
+                    .equalTo("sjkldhkdjfgjlkfg");
+            Assert.fail(TimeoutException.class.getName() + " should be thrown.");
+        } catch(TimeoutException e) {
+            long was = System.currentTimeMillis() - started;
+            Assert.assertTrue("The waiting time shouldn't be much bigger than " + duration.toMillis() + " ms, but was " + was + " ms.",
+                              was < 3000);
+            Assert.assertTrue("The waiting time shouldn't lower than " + duration.toMillis() + " ms, but was " + was + " ms.",
+                              was >= 2000);
         }
     }
 

--- a/impl/src/main/java/org/jboss/arquillian/graphene/wait/WebDriverWaitImpl.java
+++ b/impl/src/main/java/org/jboss/arquillian/graphene/wait/WebDriverWaitImpl.java
@@ -58,8 +58,20 @@ public class WebDriverWaitImpl<FLUENT> implements WebDriverWait<FLUENT> {
     }
 
     @Override
+    public FluentWait<WebDriver, FLUENT> withTimeout(Duration duration) {
+        wait.withTimeout(duration);
+        return this;
+    }
+
+    @Override
     public FluentWait<WebDriver, FLUENT> pollingEvery(long duration, TimeUnit unit) {
         wait.pollingEvery(Duration.ofMillis(unit.toMillis(duration)));
+        return this;
+    }
+
+    @Override
+    public FluentWait<WebDriver, FLUENT> pollingEvery(Duration duration) {
+        wait.pollingEvery(duration);
         return this;
     }
 


### PR DESCRIPTION
#### Short description of what this resolves:
With selenium 4, there is an option to invoke `withTimeout` and `pollingEvery` with single argument - `java.time.Duration`. We could reflect this API simplification also in arqullian-graphene.

#### Changes proposed in this pull request:
- new `withTimeout` alternative
- new `pollingEvery` alternative

