### PR TITLE
feat: removes shading of cglib/asm/objenesis

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -66,17 +66,14 @@
             <artifactId>arquillian-drone-configuration</artifactId>
         </dependency>
 
-        <!-- cglib and objenesis are implementation details required for proxying -->
-        <!-- both artifacts are shaded via shade plugin -->
         <dependency>
             <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
+            <artifactId>cglib</artifactId>
         </dependency>
         <dependency>
             <groupId>org.objenesis</groupId>
             <artifactId>objenesis</artifactId>
         </dependency>
-        <!-- end of shaded artifacts -->
 
         <dependency>
             <groupId>org.jboss.arquillian.core</groupId>
@@ -178,45 +175,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-            </plugin>
-            <!-- we need to shade cglib so it does not interfere with other cglib implementation on classpath -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>shade-proxying-implementation</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <artifactSet>
-                                <includes>
-                                    <include>asm</include>
-                                    <include>cglib</include>
-                                    <include>org.objenesis</include>
-                                </includes>
-                            </artifactSet>
-                            <relocations>
-                                <relocation>
-                                    <pattern>org.objectweb.asm</pattern>
-                                    <shadedPattern>org.jboss.arquillian.graphene.shaded.org.objectweb.asm</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>net.sf.cglib</pattern>
-                                    <shadedPattern>org.jboss.arquillian.graphene.shaded.net.sf.cglib</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.objenesis</pattern>
-                                    <shadedPattern>org.jboss.arquillian.graphene.shaded.org.objenesis</shadedPattern>
-                                </relocation>
-                            </relocations>
-                            <createSourcesJar>true</createSourcesJar>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -105,11 +105,11 @@
             </dependency>
 
 			<!-- runtime dependencies -->
-			<dependency>
-				<groupId>org.ow2.asm</groupId>
-				<artifactId>asm</artifactId>
-				<version>${version.asm}</version>
-			</dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${version.asm}</version>
+            </dependency>
             <dependency>
                 <groupId>cglib</groupId>
                 <artifactId>cglib</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <version.arquillian.drone>3.0.0-alpha.4</version.arquillian.drone>
 
         <!-- Runtime dependencies -->
+        <version.asm>9.2</version.asm>
         <version.cglib>3.3.0</version.cglib>
         <version.objenesis>1.2</version.objenesis>
 
@@ -103,10 +104,15 @@
                 <scope>import</scope>
             </dependency>
 
-            <!-- runtime dependencies -->
+			<!-- runtime dependencies -->
+			<dependency>
+				<groupId>org.ow2.asm</groupId>
+				<artifactId>asm</artifactId>
+				<version>${version.asm}</version>
+			</dependency>
             <dependency>
                 <groupId>cglib</groupId>
-                <artifactId>cglib-nodep</artifactId>
+                <artifactId>cglib</artifactId>
                 <version>${version.cglib}</version>
             </dependency>
             <dependency>
@@ -280,11 +286,6 @@
                             </goals>
                         </execution>
                     </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.2.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Graphene shades cglib-nodep, which in turn shades asm. This setup makes it impossible to override the versions of these libraries. cglib 3.3.0 depends on asm 7.1, which only supports Java class files up to JDK version 13. We are migrating from 11 to 17 and this currently breaks our build. By not shading the artifacts, it is possible to override the versions via depedency management in our own project. I've also taken the liberty to upgrade asm to 9.2 to provide out of the box support for JDK 17.