### PR TITLE
fix: removes deprecated constructor to adjust to Selenium 4.1.3

### DIFF
--- a/impl/src/main/java/org/jboss/arquillian/graphene/wait/WebDriverWaitImpl.java
+++ b/impl/src/main/java/org/jboss/arquillian/graphene/wait/WebDriverWaitImpl.java
@@ -42,7 +42,7 @@ public class WebDriverWaitImpl<FLUENT> implements WebDriverWait<FLUENT> {
     }
 
     public WebDriverWaitImpl(FLUENT fluent, WebDriver driver, long timeOutInSeconds) {
-        this(new org.openqa.selenium.support.ui.WebDriverWait(driver, timeOutInSeconds), fluent);
+        this(new org.openqa.selenium.support.ui.WebDriverWait(driver, Duration.ofSeconds(timeOutInSeconds)), fluent);
     }
 
     @Override


### PR DESCRIPTION
This PR fixes Graphene on Selenium 4.1.3. The constructor taking a long was removed in 4.1.3 after being deprecated for quite some time (at least since 4.0.0). 