### PR TITLE
fix(ftests): allows to define browsers for parallel drone tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.2.3
+  browser-tools: circleci/browser-tools@1.3.0
 jobs:
   build:
     parameters:
@@ -11,6 +11,7 @@ jobs:
     working_directory: ~/circleci-arquillian
     docker:
       - image: cimg/openjdk:<< parameters.jdk-version >>-browsers
+    resource_class: large
     steps:
       - browser-tools/install-browser-tools
       - checkout

--- a/ftest/src/test/resources/arquillian.xml
+++ b/ftest/src/test/resources/arquillian.xml
@@ -49,12 +49,12 @@
     </extension>
 
     <extension qualifier="webdriver-browser2">
-        <property name="browser">chromeHeadless</property>
+        <property name="browser">${browser:chromeHeadless}</property>
         <property name="remote">false</property>
     </extension>
 
     <extension qualifier="webdriver-browser2">
-        <property name="browser">firefox</property>
+        <property name="browser">${browser:chromeHeadless}</property>
         <property name="remote">false</property>
     </extension>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <useReleaseProfile>true</useReleaseProfile>
-        
+
         <!-- jboss-parent override -->
         <maven.compiler.argument.target>1.8</maven.compiler.argument.target>
         <maven.compiler.argument.source>1.8</maven.compiler.argument.source>
@@ -104,7 +104,7 @@
                 <scope>import</scope>
             </dependency>
 
-			<!-- runtime dependencies -->
+            <!-- runtime dependencies -->
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>


### PR DESCRIPTION
#### Short description of what this resolves:

Browsers for parallel testing were hardcoded to `chromeHeadless` - making it impossible to test against one browser.

#### Changes proposed in this pull request:

- allows defining browsers for parallel tests by using the same variable `-Dbrowser` for `mvn` build
- upgrades CircleCI machine resource class to large for faster builds