### PR TITLE
Synchronize Graphene with Arquillian Drone

### DIFF
--- a/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/selenium/TestSeleniumResourceProvider.java
+++ b/ftest/src/test/java/org/jboss/arquillian/graphene/ftest/enricher/selenium/TestSeleniumResourceProvider.java
@@ -40,8 +40,6 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.interactions.Locatable;
-import org.openqa.selenium.interactions.Mouse;
 import org.openqa.selenium.support.FindBy;
 
 /**
@@ -79,14 +77,6 @@ public class TestSeleniumResourceProvider {
     public void testJavaScriptExecutor(@ArquillianResource JavascriptExecutor executor) {
         executor.executeScript("document.title = arguments[0]", "New Title");
         assertEquals("New Title", browser.getTitle());
-    }
-
-    @Test
-    public void testMouse(@ArquillianResource Mouse mouse) {
-        // when
-        mouse.click(((Locatable) button).getCoordinates());
-        // then
-        assertEquals("Clicked", button.getAttribute("value"));
     }
 
     @Test

--- a/impl/src/main/java/org/jboss/arquillian/graphene/enricher/SeleniumResourceProvider.java
+++ b/impl/src/main/java/org/jboss/arquillian/graphene/enricher/SeleniumResourceProvider.java
@@ -37,10 +37,8 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.HasCapabilities;
 import org.openqa.selenium.html5.WebStorage;
 import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.interactions.HasInputDevices;
-import org.openqa.selenium.interactions.HasTouchScreen;
-import org.openqa.selenium.interactions.Mouse;
-import org.openqa.selenium.interactions.Keyboard;
+import org.openqa.selenium.interactions.KeyInput;
+import org.openqa.selenium.interactions.PointerInput;
 
 /**
  * Provides common Selenium objects as Arquillian resources
@@ -144,15 +142,15 @@ public abstract class SeleniumResourceProvider implements ResourceProvider {
         }
     }
 
-    public static class KeyboardProvider extends IndirectProvider<HasInputDevices> {
+    public static class KeyboardProvider extends IndirectProvider<Actions> {
         @Override
-        public Object generateProxy(HasInputDevices base) {
-            return base.getKeyboard();
+        public Object generateProxy(Actions base) {
+            return base.getActiveKeyboard();
         }
 
         @Override
         protected String getReturnType() {
-            return Keyboard.class.getName();
+            return KeyInput.class.getName();
         }
     }
 
@@ -160,15 +158,15 @@ public abstract class SeleniumResourceProvider implements ResourceProvider {
      * This is a resource provider for Mouse interface.
      * It is used in an internal code.
      */
-    public static class MouseProvider extends IndirectProvider<HasInputDevices> {
+    public static class MouseProvider extends IndirectProvider<Actions> {
         @Override
-        public Object generateProxy(HasInputDevices base) {
-            return base.getMouse();
+        public Object generateProxy(Actions base) {
+            return base.getActivePointer();
         }
 
         @Override
         protected String getReturnType() {
-            return Mouse.class.getName();
+            return PointerInput.class.getName();
         }
     }
 
@@ -184,15 +182,15 @@ public abstract class SeleniumResourceProvider implements ResourceProvider {
         }
     }
 
-    public static class TouchScreenProvider extends IndirectProvider<HasTouchScreen> {
+    public static class TouchScreenProvider extends IndirectProvider<Actions> {
         @Override
-        public Object generateProxy(HasTouchScreen base) {
-            return base.getTouch();
+        public Object generateProxy(Actions base) {
+            return base.getActivePointer();
         }
 
         @Override
         protected String getReturnType() {
-            return "org.openqa.selenium.interactions.TouchScreen";
+            return PointerInput.class.getName();
         }
     }
 
@@ -200,10 +198,10 @@ public abstract class SeleniumResourceProvider implements ResourceProvider {
      * This is a resource provider for Action interface.
      * It is used in an internal code.
      */
-    public static class ActionsProvider extends IndirectProvider<HasInputDevices> {
+    public static class ActionsProvider extends IndirectProvider<Actions> {
         @Override
-        public Object generateProxy(HasInputDevices base) {
-            return new Actions ((WebDriver) base);
+        public Object generateProxy(Actions base) {
+            return new Actions((WebDriver) base);
         }
 
         @Override

--- a/impl/src/test/java/org/jboss/arquillian/graphene/GrapheneActionOperationsBootstrap.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/GrapheneActionOperationsBootstrap.java
@@ -28,33 +28,27 @@ import org.junit.After;
 import org.junit.Before;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.htmlunit.HtmlUnitWebElement;
-import org.openqa.selenium.interactions.HasInputDevices;
-import org.openqa.selenium.interactions.Keyboard;
-import org.openqa.selenium.interactions.Mouse;
+import org.openqa.selenium.interactions.Actions;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 public abstract class GrapheneActionOperationsBootstrap {
 
     HtmlUnitDriver driver;
-    Mouse mouse;
-    Keyboard keyboard;
+    Actions mouse;
+    Actions keyboard;
     HtmlUnitWebElement webElement;
 
     @Before
     public final void setUp() {
-        driver = mock(HtmlUnitDriver.class, withSettings().extraInterfaces(HasInputDevices.class));
-        mouse = mock(Mouse.class);
-        keyboard = mock(Keyboard.class);
+        driver = mock(HtmlUnitDriver.class, withSettings());
+        mouse = mock(Actions.class);
+        keyboard = mock(Actions.class);
         webElement = mock(HtmlUnitWebElement.class);
 
         GrapheneContext.setContextFor(new GrapheneConfiguration(), driver, Default.class);
         GrapheneRuntime.pushInstance(new DefaultGrapheneRuntime());
-
-        when(((HasInputDevices) driver).getMouse()).thenReturn(mouse);
-        when(((HasInputDevices) driver).getKeyboard()).thenReturn(keyboard);
     }
 
     @After

--- a/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneActionOperations.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneActionOperations.java
@@ -22,7 +22,6 @@
 package org.jboss.arquillian.graphene;
 
 import org.junit.Test;
-import org.openqa.selenium.interactions.Locatable;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -35,7 +34,7 @@ public class TestGrapheneActionOperations extends GrapheneActionOperationsBootst
         Graphene.click(webElement);
 
         // then
-        verify(mouse).click(((Locatable) webElement).getCoordinates());
+        verify(mouse).click(webElement);
         verifyNoMoreInteractions(mouse, keyboard);
     }
 
@@ -45,7 +44,7 @@ public class TestGrapheneActionOperations extends GrapheneActionOperationsBootst
         Graphene.doubleClick(webElement);
 
         // then
-        verify(mouse).doubleClick(((Locatable) webElement).getCoordinates());
+        verify(mouse).doubleClick(webElement);
         verifyNoMoreInteractions(mouse, keyboard);
     }
 
@@ -55,8 +54,8 @@ public class TestGrapheneActionOperations extends GrapheneActionOperationsBootst
         Graphene.writeIntoElement(webElement, "hi");
 
         // then
-        verify(mouse).mouseMove(((Locatable) webElement).getCoordinates());
-        verify(mouse).click(((Locatable) webElement).getCoordinates());
+        verify(mouse).moveToElement(webElement);
+        verify(mouse).click(webElement);
         verify(keyboard).sendKeys("hi");
         verifyNoMoreInteractions(mouse, keyboard);
     }

--- a/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneElementActionOperations.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/TestGrapheneElementActionOperations.java
@@ -43,7 +43,7 @@ public class TestGrapheneElementActionOperations extends GrapheneActionOperation
         grapheneElement.doubleClick();
 
         // then
-        verify(mouse).doubleClick(grapheneElement.getCoordinates());
+        verify(mouse).doubleClick(grapheneElement);
         verifyNoMoreInteractions(mouse, keyboard);
     }
 
@@ -53,8 +53,8 @@ public class TestGrapheneElementActionOperations extends GrapheneActionOperation
         grapheneElement.writeIntoElement("hi");
 
         // then
-        verify(mouse).mouseMove(grapheneElement.getCoordinates());
-        verify(mouse).click(grapheneElement.getCoordinates());
+        verify(mouse).moveToElement(grapheneElement);
+        verify(mouse).click(grapheneElement);
         verify(keyboard).sendKeys("hi");
         verifyNoMoreInteractions(mouse, keyboard);
     }

--- a/impl/src/test/java/org/jboss/arquillian/graphene/TestingDriver.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/TestingDriver.java
@@ -26,13 +26,12 @@ import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.SearchContext;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.interactions.HasInputDevices;
 
 /**
  * @author Lukas Fryc
  */
-public interface TestingDriver extends WebDriver, HasCapabilities, HasInputDevices, JavascriptExecutor, SearchContext,
+public interface TestingDriver extends WebDriver, HasCapabilities, JavascriptExecutor, SearchContext,
         TakesScreenshot {
 
-    Class<?>[] INTERFACES = new Class<?>[] { WebDriver.class, HasCapabilities.class, HasInputDevices.class, JavascriptExecutor.class, SearchContext.class, TakesScreenshot.class };
+    Class<?>[] INTERFACES = new Class<?>[] { WebDriver.class, HasCapabilities.class, JavascriptExecutor.class, SearchContext.class, TakesScreenshot.class };
 }

--- a/impl/src/test/java/org/jboss/arquillian/graphene/TestingDriverStub.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/TestingDriverStub.java
@@ -29,8 +29,6 @@ import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Keyboard;
-import org.openqa.selenium.interactions.Mouse;
 
 /**
  * @author Lukas Fryc
@@ -100,16 +98,6 @@ public class TestingDriverStub implements TestingDriver {
     }
 
     public Capabilities getCapabilities() {
-
-        return null;
-    }
-
-    public Keyboard getKeyboard() {
-
-        return null;
-    }
-
-    public Mouse getMouse() {
 
         return null;
     }

--- a/impl/src/test/java/org/jboss/arquillian/graphene/enricher/TestSeleniumResourceProvider.java
+++ b/impl/src/test/java/org/jboss/arquillian/graphene/enricher/TestSeleniumResourceProvider.java
@@ -21,21 +21,11 @@
  */
 package org.jboss.arquillian.graphene.enricher;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
-
 import org.jboss.arquillian.drone.api.annotation.Default;
 import org.jboss.arquillian.graphene.DefaultGrapheneRuntime;
 import org.jboss.arquillian.graphene.GrapheneRuntime;
 import org.jboss.arquillian.graphene.context.GrapheneContext;
 import org.jboss.arquillian.graphene.enricher.SeleniumResourceProvider.ActionsProvider;
-import org.jboss.arquillian.graphene.enricher.SeleniumResourceProvider.KeyboardProvider;
-import org.jboss.arquillian.graphene.enricher.SeleniumResourceProvider.MouseProvider;
 import org.jboss.arquillian.graphene.enricher.SeleniumResourceProvider.WebDriverProvider;
 import org.jboss.arquillian.graphene.proxy.GrapheneProxyInstance;
 import org.jboss.arquillian.graphene.spi.configuration.GrapheneConfiguration;
@@ -48,75 +38,20 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.interactions.Coordinates;
-import org.openqa.selenium.interactions.HasInputDevices;
-import org.openqa.selenium.interactions.Keyboard;
-import org.openqa.selenium.interactions.Mouse;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Lukas Fryc
  */
-@RunWith(MockitoJUnitRunner.class)
-public class TestSeleniumResourceProvider {
+public class TestSeleniumResourceProvider extends AbstractGrapheneEnricherTest{
 
-    @Mock(extraInterfaces = HasInputDevices.class)
     WebDriver driver;
 
     @Before
     public void setUp() {
-        when(((HasInputDevices) driver).getKeyboard()).thenReturn(new Keyboard() {
-            @Override
-            public void sendKeys(CharSequence... keysToSend) {
-                throw new UnsupportedOperationException("Not supported yet.");
-            }
-
-            @Override
-            public void pressKey(CharSequence keyToPress) {
-                throw new UnsupportedOperationException("Not supported yet.");
-            }
-
-            @Override
-            public void releaseKey(CharSequence keyToRelease) {
-                throw new UnsupportedOperationException("Not supported yet.");
-            }
-        });
-        when(((HasInputDevices) driver).getMouse()).thenReturn(new Mouse() {
-
-            @Override
-            public void click(Coordinates where) {
-                throw new UnsupportedOperationException("Not supported yet.");
-            }
-
-            @Override
-            public void doubleClick(Coordinates where) {
-                throw new UnsupportedOperationException("Not supported yet.");
-            }
-
-            @Override
-            public void mouseDown(Coordinates where) {
-                throw new UnsupportedOperationException("Not supported yet.");
-            }
-
-            @Override
-            public void mouseUp(Coordinates where) {
-                throw new UnsupportedOperationException("Not supported yet.");
-            }
-
-            @Override
-            public void mouseMove(Coordinates where) {
-                throw new UnsupportedOperationException("Not supported yet.");
-            }
-
-            @Override
-            public void mouseMove(Coordinates where, long xOffset, long yOffset) {
-                throw new UnsupportedOperationException("Not supported yet.");
-            }
-
-            @Override
-            public void contextClick(Coordinates where) {
-                throw new UnsupportedOperationException("Not supported yet.");
-            }
-        });
         GrapheneContext.setContextFor(new GrapheneConfiguration(), driver, Default.class);
         GrapheneRuntime.pushInstance(new DefaultGrapheneRuntime());
     }
@@ -149,49 +84,20 @@ public class TestSeleniumResourceProvider {
     @Test
     public void testIndirectProviderCanProvideMethod() {
         // having
-        KeyboardProvider provider = new KeyboardProvider();
+        ActionsProvider provider = new ActionsProvider();
         // then
-        assertTrue(provider.canProvide(Keyboard.class));
-        assertFalse(provider.canProvide(Mouse.class));
+        assertTrue(provider.canProvide(Actions.class));
     }
 
     @Test
     public void testIndirectProviderLookup() {
         // having
-        KeyboardProvider provider = new KeyboardProvider();
-        // when
-        Object object = provider.lookup(null, null);
-        // then
-        assertNotNull(object);
-        assertTrue(object instanceof Keyboard);
-        assertTrue(object instanceof GrapheneProxyInstance);
-    }
-
-    @Test
-    public void testMouseProviderLookup() {
-        // having
-        MouseProvider provider = new MouseProvider();
-        // when
-        Object object = provider.lookup(null, null);
-        // then
-        assertNotNull(object);
-        assertTrue(object instanceof Mouse);
-        assertTrue(object instanceof GrapheneProxyInstance);
-    }
-
-    @Test
-    public void testActionsProviderLookup() {
-        // having
         ActionsProvider provider = new ActionsProvider();
-        Mouse mouse = mock(Mouse.class);
-        Keyboard keyboard = mock(Keyboard.class);
-        when(((HasInputDevices) driver).getMouse()).thenReturn(mouse);
-        when(((HasInputDevices) driver).getKeyboard()).thenReturn(keyboard);
         // when
-        Actions actions = (Actions) provider.lookup(null, null);
-        actions.click().perform();
+        Object object = provider.lookup(null, null);
         // then
-        verify(mouse).click(null);
-        verifyNoMoreInteractions(mouse, keyboard);
+        assertNotNull(object);
+        assertTrue(object instanceof Actions);
+        assertTrue(object instanceof GrapheneProxyInstance);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
         <!-- Arquillian -->
         <version.arquillian.core>1.6.0.Final</version.arquillian.core>
-        <version.arquillian.drone>3.0.0-alpha.5</version.arquillian.drone>
+        <version.arquillian.drone>3.0.0-alpha.7</version.arquillian.drone>
 
         <!-- Runtime dependencies -->
         <version.asm>9.4</version.asm>


### PR DESCRIPTION
#### Short description of what this resolves:
Some interaction elements were removed after Selenium 4.1.x, and as Arquillian Drone uses Selenium 4.3, it'd be good to have Graphene and Drone synced. 

@bartoszmajsak I'm not sure how these tests are executed, but also, tests from the latest upstream master branch failed.  
