### PR TITLE
bugfix: removed unbuildable components from javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,12 +278,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <configuration>
-                        <doclet>org.jboss.apiviz.APIviz</doclet>
-                        <docletArtifact>
-                            <groupId>org.jboss.apiviz</groupId>
-                            <artifactId>apiviz</artifactId>
-                            <version>1.3.2.GA</version>
-                        </docletArtifact>
                         <useStandardDocletOptions>true</useStandardDocletOptions>
                         <charset>UTF-8</charset>
                         <encoding>UTF-8</encoding>
@@ -292,11 +286,6 @@
                         <version>true</version>
                         <author>true</author>
                         <keywords>true</keywords>
-                        <additionalJOptions>
-                            <additionalJOption>
-                                -sourceclasspath ${project.build.outputDirectory}
-                            </additionalJOption>
-                        </additionalJOptions>
                         <javadocDirectory>${project.parent.parent.basedir}/javadoc</javadocDirectory>
                     </configuration>
                     <executions>


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
Fixes Javadoc generation > JDK 11
Relates to #245 

