### PR TITLE
Upgrade Selenium from 4.19.1 to 4.40.0

### DIFF
--- a/extension/screenshooter/src/test/resources/arquillian.xml
+++ b/extension/screenshooter/src/test/resources/arquillian.xml
@@ -22,8 +22,8 @@
     02110-1301 USA, or see the FSF site: http://www.fsf.org.
 
 -->
-<arquillian xmlns="http://jboss.com/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
     <engine>
         <property name="deploymentExportPath">target/</property>
@@ -32,7 +32,6 @@
     <extension qualifier="webdriver">
         <property name="browser">${browser:chromeHeadless}</property>
         <property name="remote">${remote}</property>
-        <property name="platform">${platform}</property>
         <property name="version">${browser.version}</property>
         <property name="remoteReusable">${remoteReusable}</property>
         <property name="remoteAddress">${remoteAddress}</property>
@@ -43,7 +42,7 @@
         <property name="port">4444</property>
         <property name="skip">false</property>
     </extension>
-    
+
     <extension qualifier="screenshooter">
         <property name="takeOnEveryAction">true</property>
         <property name="takeBeforeTest">true</property>
@@ -55,12 +54,9 @@
         <property name="report">html5</property>
     </extension>
 
-
     <container qualifier="tomcat7" default="true">
         <configuration>
-            <property name="javaVmArguments">-Xms1024m -Xmx1024m ${maxPermSizeArg} -Dcom.sun.management.jmxremote
-                -Dcom.sun.management.jmxremote.port=8089 -Djava.rmi.server.hostname=localhost
-            </property>
+            <property name="javaVmArguments">-Xms1024m -Xmx1024m ${maxPermSizeArg} -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8089 -Djava.rmi.server.hostname=localhost</property>
             <property name="user">tomcat</property>
             <property name="pass">tomcat</property>
             <property name="catalinaHome">target/apache-tomcat-7.0.55</property>

--- a/extension/screenshooter/src/test/resources/when/arquillian.xml
+++ b/extension/screenshooter/src/test/resources/when/arquillian.xml
@@ -22,8 +22,7 @@
     02110-1301 USA, or see the FSF site: http://www.fsf.org.
 
 -->
-<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns="http://jboss.org/schema/arquillian"
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
     <extension qualifier="screenshooter">

--- a/ftest/src/test/resources/arquillian.xml
+++ b/ftest/src/test/resources/arquillian.xml
@@ -22,8 +22,8 @@
     02110-1301 USA, or see the FSF site: http://www.fsf.org.
 
 -->
-<arquillian xmlns="http://jboss.com/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
     <engine>
         <property name="deploymentExportPath">target/</property>
@@ -36,7 +36,6 @@
     <extension qualifier="webdriver">
         <property name="browser">${browser:chromeHeadless}</property>
         <property name="remote">${remote}</property>
-        <property name="platform">${platform}</property>
         <property name="version">${browser.version}</property>
         <property name="remoteReusable">${remoteReusable}</property>
         <property name="remoteAddress">${remoteAddress}</property>
@@ -44,11 +43,6 @@
     </extension>
 
     <extension qualifier="webdriver-browser1">
-        <property name="browser">${browser:chromeHeadless}</property>
-        <property name="remote">false</property>
-    </extension>
-
-    <extension qualifier="webdriver-browser2">
         <property name="browser">${browser:chromeHeadless}</property>
         <property name="remote">false</property>
     </extension>
@@ -79,11 +73,7 @@
 
     <container qualifier="tomcat7" default="true">
         <configuration>
-            <property name="javaVmArguments">-Xms1024m -Xmx1024m ${maxPermSizeArg}
-                -Dcom.sun.management.jmxremote
-            -Dcom.sun.management.jmxremote.port=8089
-            -Djava.rmi.server.hostname=localhost
-            </property>
+            <property name="javaVmArguments">-Xms1024m -Xmx1024m ${maxPermSizeArg} -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.port=8089 -Djava.rmi.server.hostname=localhost</property>
             <property name="user">tomcat</property>
             <property name="pass">tomcat</property>
             <property name="catalinaHome">target/apache-tomcat-7.0.55</property>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <!-- Runtime dependencies -->
         <version.asm>9.9.1</version.asm>
         <version.objenesis>3.4</version.objenesis>
-        <version.selenium>4.19.1</version.selenium>
+        <version.selenium>4.40.0</version.selenium>
 
         <!-- Tests -->
         <version.junit>4.13.2</version.junit>


### PR DESCRIPTION
- Remove deprecated platform property from arquillian.xml files
- Clean up XML formatting in test resources
