### PR TITLE
chore: Selenium verions are managed by Drone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
         <!-- Runtime dependencies -->
         <version.asm>9.9.1</version.asm>
         <version.objenesis>3.4</version.objenesis>
-        <version.selenium>4.40.0</version.selenium>
 
         <!-- Tests -->
         <version.junit>4.13.2</version.junit>
@@ -101,22 +100,6 @@
                 <version>${version.arquillian.drone}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <!-- Selenium dependencies -->
-            <dependency>
-                <groupId>org.seleniumhq.selenium</groupId>
-                <artifactId>selenium-bom</artifactId>
-                <version>${version.selenium}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <!-- HtmlUnit is kept externally from Selenium BOM -->
-            <dependency>
-                <groupId>org.seleniumhq.selenium</groupId>
-                <artifactId>htmlunit3-driver</artifactId>
-                <version>${version.selenium}</version>
             </dependency>
 
             <!-- runtime dependencies -->


### PR DESCRIPTION
Selenium and HtmlUnit driver versions are dependencies of Drone rather than here.
No need to add extra (transitive) dependencies here.